### PR TITLE
Improve collage responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,9 @@
     .hero{padding:2em 1em;text-align:center;}
     .collage{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:1em;}
     .collage img{
-      width:calc(50% - 10px);
-      max-width:360px;
+      flex:0 0 calc(50% - 10px);
+      max-width:100%;
+      width:100%;
       border-radius:8px;
       transition:transform 0.3s ease, box-shadow 0.3s ease;
     }
@@ -29,7 +30,9 @@
       transform:scale(1.05);
       box-shadow:0 4px 12px rgba(0,0,0,0.3);
     }
-    @media(max-width:600px){.collage img{width:100%;}}
+    @media(max-width:600px){
+      .collage img{flex-basis:100%;}
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- make the index page image collage consistently use two columns on wide screens
- stack images in a single column on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684339b68c5483208b8101bf356d3c22