### PR TITLE
Fix image links for Dec/Jan newsletter

### DIFF
--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -93,7 +93,7 @@
 
     <!-- Acoustic Monitoring -->
     <table role="presentation" width="100%" class="card"><tr>
-      <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/DecJan2025/Acoustic.jpg" alt="Bull Trout map in Keechelus"></td>
+      <td class="imgCol"><img src="Acoustic_DEC.png" alt="Bull Trout map in Keechelus"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Acoustic Monitoring</h2>
         <p class="subhead">Bull Trout in Keechelus Reservoir</p>
@@ -108,11 +108,12 @@
         <p class="subhead">Monitoring in Toppenish Creek</p>
         <p>Adult Steelhead are once again appearing in Toppenish Creek. Our PIT antennas at Toppenish National Wildlife Refuge first detected a returning fish on December&nbsp;26, 2024. So far nine adults have been logged, most tagged throughout the Columbia River Basin in 2024. At this point last year we had documented only a single adult. These detections help us track straying fish in irrigation structures and guide actions to improve survival through the refuge.</p>
       </td>
-      <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/DecJan2025/Steelhead.jpg" alt="Steelhead at Toppenish"></td>
+      <td class="imgCol"><img src="Steelhead_DEC.png" alt="Steelhead at Toppenish"></td>
     </tr></table>
 
     <!-- Working with Partners -->
     <table role="presentation" width="100%" class="card"><tr><td class="pad">
+      <img src="Partners_DEC.png" alt="Bull Trout Working Group partners" style="margin-bottom:16px;">
       <h2 style="text-align:center;">Working with Partners</h2>
       <p class="subhead">2024 Summaries from the Bull Trout Working Group</p>
       <p>Partners across the Yakima Basin shared highlights from 2024. Yakama Nation Fisheries found little large woody debris and limited habitat complexity in the South Fork Tieton River. WDFW counted <strong>403</strong> Bull Trout redds basinwide, below the 20‑year average of <strong>488</strong>, with most of the decline in the South Fork Tieton. Mid-Columbia Fisheries Enhancement Group reported that <strong>44%</strong> of their eDNA samples from Waptus and Cooper rivers were positive for Brook Trout, while none detected Bull Trout.</p>
@@ -129,7 +130,7 @@
 
     <!-- KRD Antenna Shutdowns -->
     <table role="presentation" width="100%" class="card"><tr>
-      <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/DecJan2025/KRD.jpg" alt="KRD PIT antenna site"></td>
+      <td class="imgCol"><img src="KRD_DEC.png" alt="KRD PIT antenna site"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">KRD Antenna Shutdowns</h2>
         <p class="subhead">Antennas Off for the Winter</p>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <p>Select a month below to explore each issue.</p>
     <div class="issue-grid">
       <a class="issue-card" href="DecJan2025/DecJan2025Newsletter.html">
-        <img src="DecJan2025/Acoustic.jpg" alt="Dec &amp; Jan 2025">
+        <img src="DecJan2025/Acoustic_DEC.png" alt="Dec &amp; Jan 2025">
         <span>Dec &amp; Jan 2025</span>
       </a>
       <a class="issue-card" href="April2025/MarchApril2025Newsletter.html">


### PR DESCRIPTION
## Summary
- update DecJan2025 newsletter to use local PNG images
- insert partners image into the article
- fix preview image link on the index page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435cc708b48320922cbacf0cbf8bda