### PR TITLE
Fix partners image layout

### DIFF
--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -112,12 +112,14 @@
     </tr></table>
 
     <!-- Working with Partners -->
-    <table role="presentation" width="100%" class="card"><tr><td class="pad">
-      <img src="Partners_DEC.png" alt="Bull Trout Working Group partners" style="margin-bottom:16px;">
-      <h2 style="text-align:center;">Working with Partners</h2>
-      <p class="subhead">2024 Summaries from the Bull Trout Working Group</p>
-      <p>Partners across the Yakima Basin shared highlights from 2024. Yakama Nation Fisheries found little large woody debris and limited habitat complexity in the South Fork Tieton River. WDFW counted <strong>403</strong> Bull Trout redds basinwide, below the 20‑year average of <strong>488</strong>, with most of the decline in the South Fork Tieton. Mid-Columbia Fisheries Enhancement Group reported that <strong>44%</strong> of their eDNA samples from Waptus and Cooper rivers were positive for Brook Trout, while none detected Bull Trout.</p>
-    </td></tr></table>
+    <table role="presentation" width="100%" class="card"><tr>
+      <td class="txtCol pad">
+        <h2 style="text-align:center;">Working with Partners</h2>
+        <p class="subhead">2024 Summaries from the Bull Trout Working Group</p>
+        <p>Partners across the Yakima Basin shared highlights from 2024. Yakama Nation Fisheries found little large woody debris and limited habitat complexity in the South Fork Tieton River. WDFW counted <strong>403</strong> Bull Trout redds basinwide, below the 20‑year average of <strong>488</strong>, with most of the decline in the South Fork Tieton. Mid-Columbia Fisheries Enhancement Group reported that <strong>44%</strong> of their eDNA samples from Waptus and Cooper rivers were positive for Brook Trout, while none detected Bull Trout.</p>
+      </td>
+      <td class="imgCol"><img src="Partners_DEC.png" alt="Bull Trout Working Group partners"></td>
+    </tr></table>
 
     <!-- New and Upcoming Reports -->
     <table role="presentation" width="100%" class="card"><tr><td class="pad">


### PR DESCRIPTION
## Summary
- move the "Working with Partners" image into an `imgCol` cell
- keep text in a separate cell so the image sits beside or below text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435ebe49448320937a8cfac046d2dd