### PR TITLE
Update website styles to use new palette

### DIFF
--- a/April2025/MarchApril2025Newsletter.html
+++ b/April2025/MarchApril2025Newsletter.html
@@ -11,28 +11,36 @@
   <meta property="og:type" content="article">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <style>
-    body{margin:0;padding:0;background:#FDFBF6;font-family:'Inter',Arial,Helvetica,sans-serif;color:#343434;}
+    :root{
+      --primary:#4C7EB0;
+      --secondary:#FFD966;
+      --accent1:#F4A261;
+      --accent2:#E8D8C3;
+      --neutral-light:#FDFBF6;
+      --highlight:#88C3D0;
+    }
+    body{margin:0;padding:0;background:var(--neutral-light);font-family:'Inter',Arial,Helvetica,sans-serif;color:#343434;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
     h1,h2{margin:0;font-family:'Playfair Display',serif;}
-    h1{font-size:44px;line-height:50px;font-weight:700;color:#FDFBF6;letter-spacing:0.6px;}
-    h2{font-size:30px;line-height:36px;font-weight:700;color:#4C7EB0;letter-spacing:0.25px;}
+    h1{font-size:44px;line-height:50px;font-weight:700;color:var(--neutral-light);letter-spacing:0.6px;}
+    h2{font-size:30px;line-height:36px;font-weight:700;color:var(--primary);letter-spacing:0.25px;}
     p{margin:16px 0;font-size:19px;line-height:1.65;}
     ul{margin:16px 0 0 0;padding-left:28px;font-size:19px;line-height:1.65;}
 
-    .mast{background:#4A3B2A;border-radius:0 0 16px 16px;}
+    .mast{background:var(--primary);border-radius:0 0 16px 16px;}
     .mastInner td{vertical-align:bottom;}
     .mastInner .titleCell{padding:60px 4%;text-align:center;}
     .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
 
-    .card{background:#E8D8C3;border:1px solid #d7c4aa;border-radius:16px;margin-top:36px;overflow:hidden;}
+    .card{background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
     .subhead{font-size:21px;font-weight:700;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#222;letter-spacing:0.3px;}
     .menu-bar{
-      background:#4A3B2A;
+      background:var(--primary);
       padding:0.5em 1em;
       position:sticky;
       top:0;
@@ -41,14 +49,14 @@
     }
     .menu-btn{
       font-size:26px;
-      color:#FDFBF6;
+      color:var(--neutral-light);
       background:none;
       border:none;
       cursor:pointer;
     }
     .home-btn{
       font-size:26px;
-      color:#FDFBF6;
+      color:var(--neutral-light);
       text-decoration:none;
       margin-left:0.5em;
     }
@@ -62,11 +70,11 @@
       height:calc(100% - 3em);
       padding:1em;
       gap:0.5em;
-      background:#4A3B2A;
+      background:var(--primary);
       z-index:101;
     }
     .menu-items a{
-      color:#FDFBF6;
+      color:var(--neutral-light);
       text-decoration:none;
       font-size:22px;
       margin:0.25em 0;
@@ -97,22 +105,22 @@
     </div>
   </nav>
 
-  <table role="presentation" bgcolor="#FDFBF6" cellspacing="0" cellpadding="0"><tr><td>
+  <table role="presentation" bgcolor="var(--neutral-light)" cellspacing="0" cellpadding="0"><tr><td>
 
     <!-- Masthead: robust blue background & inline logo -->
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4A3B2A" style="background:#4A3B2A;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="var(--primary)" style="background:var(--primary);">
       <tr>
-        <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:0;">
+        <td bgcolor="var(--primary)" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
             <tr>
-              <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:0 0 12px 4%; width:180px;" valign="bottom">
+              <td bgcolor="var(--primary)" style="background:var(--primary); padding:0 0 12px 4%; width:180px;" valign="bottom">
                  <img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/logo/USFWS%20Logo.jpg.webp" alt="USFWS logo" width="180" style="display:block;border:0;width:100%;height:auto;">
               </td>
-              <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:60px 4%;" align="center" valign="bottom">
-                <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:#FDFBF6;margin:0;">
+              <td bgcolor="var(--primary)" style="background:var(--primary); padding:60px 4%;" align="center" valign="bottom">
+                <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:var(--neutral-light);margin:0;">
                   U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter
                 </h1>
-                <p style="margin:12px 0 0;font-size:22px;font-weight:600;letter-spacing:0.3px;color:#dbe6f3;">
+                <p style="margin:12px 0 0;font-size:22px;font-weight:600;letter-spacing:0.3px;color:var(--highlight);">
                   March&nbsp;&amp;&nbsp;April&nbsp;2025
                 </p>
               </td>

--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -11,28 +11,36 @@
   <meta property="og:type" content="article">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <style>
-    body{margin:0;padding:0;background:#FDFBF6;font-family:'Inter',Arial,Helvetica,sans-serif;color:#343434;}
+    :root{
+      --primary:#4C7EB0;
+      --secondary:#FFD966;
+      --accent1:#F4A261;
+      --accent2:#E8D8C3;
+      --neutral-light:#FDFBF6;
+      --highlight:#88C3D0;
+    }
+    body{margin:0;padding:0;background:var(--neutral-light);font-family:'Inter',Arial,Helvetica,sans-serif;color:#343434;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
     h1,h2{margin:0;font-family:'Playfair Display',serif;}
-    h1{font-size:44px;line-height:50px;font-weight:700;color:#FDFBF6;letter-spacing:0.6px;}
-    h2{font-size:30px;line-height:36px;font-weight:700;color:#4C7EB0;letter-spacing:0.25px;}
+    h1{font-size:44px;line-height:50px;font-weight:700;color:var(--neutral-light);letter-spacing:0.6px;}
+    h2{font-size:30px;line-height:36px;font-weight:700;color:var(--primary);letter-spacing:0.25px;}
     p{margin:16px 0;font-size:19px;line-height:1.65;}
     ul{margin:16px 0 0 0;padding-left:28px;font-size:19px;line-height:1.65;}
 
-    .mast{background:#4A3B2A;border-radius:0 0 16px 16px;}
+    .mast{background:var(--primary);border-radius:0 0 16px 16px;}
     .mastInner td{vertical-align:bottom;}
     .mastInner .titleCell{padding:60px 4%;text-align:center;}
     .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
 
-    .card{background:#E8D8C3;border:1px solid #d7c4aa;border-radius:16px;margin-top:36px;overflow:hidden;}
+    .card{background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
     .subhead{font-size:21px;font-weight:700;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#222;letter-spacing:0.3px;}
     .menu-bar{
-      background:#4A3B2A;
+      background:var(--primary);
       padding:0.5em 1em;
       position:sticky;
       top:0;
@@ -41,14 +49,14 @@
     }
     .menu-btn{
       font-size:26px;
-      color:#FDFBF6;
+      color:var(--neutral-light);
       background:none;
       border:none;
       cursor:pointer;
     }
     .home-btn{
       font-size:26px;
-      color:#FDFBF6;
+      color:var(--neutral-light);
       text-decoration:none;
       margin-left:0.5em;
     }
@@ -62,11 +70,11 @@
       height:calc(100% - 3em);
       padding:1em;
       gap:0.5em;
-      background:#4A3B2A;
+      background:var(--primary);
       z-index:101;
     }
     .menu-items a{
-      color:#FDFBF6;
+      color:var(--neutral-light);
       text-decoration:none;
       font-size:22px;
       margin:0.25em 0;
@@ -96,22 +104,22 @@
     </div>
   </nav>
 
-  <table role="presentation" bgcolor="#FDFBF6" cellspacing="0" cellpadding="0"><tr><td>
+  <table role="presentation" bgcolor="var(--neutral-light)" cellspacing="0" cellpadding="0"><tr><td>
 
     <!-- Masthead -->
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4A3B2A" style="background:#4A3B2A;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="var(--primary)" style="background:var(--primary);">
       <tr>
-        <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:0;">
+        <td bgcolor="var(--primary)" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
             <tr>
-              <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:0 0 12px 4%; width:180px;" valign="bottom">
+              <td bgcolor="var(--primary)" style="background:var(--primary); padding:0 0 12px 4%; width:180px;" valign="bottom">
                 <img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/logo/USFWS%20Logo.jpg.webp" alt="USFWS logo" width="180" style="display:block;border:0;width:100%;height:auto;">
               </td>
-              <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:60px 4%;" align="center" valign="bottom">
-                <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:#FDFBF6;margin:0;">
+              <td bgcolor="var(--primary)" style="background:var(--primary); padding:60px 4%;" align="center" valign="bottom">
+                <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:var(--neutral-light);margin:0;">
                   U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter
                 </h1>
-                <p style="margin:12px 0 0;font-size:22px;font-weight:600;letter-spacing:0.3px;color:#dbe6f3;">
+                <p style="margin:12px 0 0;font-size:22px;font-weight:600;letter-spacing:0.3px;color:var(--highlight);">
                   December&nbsp;2024&nbsp;&amp;&nbsp;January&nbsp;2025
                 </p>
               </td>

--- a/May2025/May2025Newsletter.html
+++ b/May2025/May2025Newsletter.html
@@ -11,28 +11,36 @@
   <meta property="og:type" content="article">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <style>
-    body{margin:0;padding:0;background:#FDFBF6;font-family:'Inter',Arial,Helvetica,sans-serif;color:#343434;}
+    :root{
+      --primary:#4C7EB0;
+      --secondary:#FFD966;
+      --accent1:#F4A261;
+      --accent2:#E8D8C3;
+      --neutral-light:#FDFBF6;
+      --highlight:#88C3D0;
+    }
+    body{margin:0;padding:0;background:var(--neutral-light);font-family:'Inter',Arial,Helvetica,sans-serif;color:#343434;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
     h1,h2{margin:0;font-family:'Playfair Display',serif;}
-    h1{font-size:44px;line-height:50px;font-weight:700;color:#FDFBF6;letter-spacing:0.6px;}
-    h2{font-size:30px;line-height:36px;font-weight:700;color:#4C7EB0;letter-spacing:0.25px;}
+    h1{font-size:44px;line-height:50px;font-weight:700;color:var(--neutral-light);letter-spacing:0.6px;}
+    h2{font-size:30px;line-height:36px;font-weight:700;color:var(--primary);letter-spacing:0.25px;}
     p{margin:16px 0;font-size:19px;line-height:1.65;}
     ul{margin:16px 0 0 0;padding-left:28px;font-size:19px;line-height:1.65;}
 
-    .mast{background:#4A3B2A;border-radius:0 0 16px 16px;}
+    .mast{background:var(--primary);border-radius:0 0 16px 16px;}
     .mastInner td{vertical-align:bottom;}
     .mastInner .titleCell{padding:60px 4%;text-align:center;}
     .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
 
-    .card{background:#E8D8C3;border:1px solid #d7c4aa;border-radius:16px;margin-top:36px;overflow:hidden;}
+    .card{background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
     .subhead{font-size:21px;font-weight:700;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#222;letter-spacing:0.3px;}
     .menu-bar{
-      background:#4A3B2A;
+      background:var(--primary);
       padding:0.5em 1em;
       position:sticky;
       top:0;
@@ -41,14 +49,14 @@
     }
     .menu-btn{
       font-size:26px;
-      color:#FDFBF6;
+      color:var(--neutral-light);
       background:none;
       border:none;
       cursor:pointer;
     }
     .home-btn{
       font-size:26px;
-      color:#FDFBF6;
+      color:var(--neutral-light);
       text-decoration:none;
       margin-left:0.5em;
     }
@@ -62,11 +70,11 @@
       height:calc(100% - 3em);
       padding:1em;
       gap:0.5em;
-      background:#4A3B2A;
+      background:var(--primary);
       z-index:101;
     }
     .menu-items a{
-      color:#FDFBF6;
+      color:var(--neutral-light);
       text-decoration:none;
       font-size:22px;
       margin:0.25em 0;
@@ -97,22 +105,22 @@
     </div>
   </nav>
 
-  <table role="presentation" bgcolor="#FDFBF6" cellspacing="0" cellpadding="0"><tr><td>
+  <table role="presentation" bgcolor="var(--neutral-light)" cellspacing="0" cellpadding="0"><tr><td>
 
     <!-- Masthead: robust blue background & inline logo -->
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4A3B2A" style="background:#4A3B2A;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="var(--primary)" style="background:var(--primary);">
       <tr>
-        <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:0;">
+        <td bgcolor="var(--primary)" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
             <tr>
-              <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:0 0 12px 4%; width:180px;" valign="bottom">
+              <td bgcolor="var(--primary)" style="background:var(--primary); padding:0 0 12px 4%; width:180px;" valign="bottom">
                 <img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/logo/USFWS%20Logo.jpg.webp" alt="USFWS logo" width="180" style="display:block;border:0;width:100%;height:auto;">
               </td>
-              <td bgcolor="#4A3B2A" style="background:#4A3B2A; padding:60px 4%;" align="center" valign="bottom">
-                <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:#FDFBF6;margin:0;">
+              <td bgcolor="var(--primary)" style="background:var(--primary); padding:60px 4%;" align="center" valign="bottom">
+                <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:var(--neutral-light);margin:0;">
                   U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter
                 </h1>
-                <p style="margin:12px 0 0;font-size:22px;font-weight:600;letter-spacing:0.3px;color:#dbe6f3;">
+                <p style="margin:12px 0 0;font-size:22px;font-weight:600;letter-spacing:0.3px;color:var(--highlight);">
                   May&nbsp;2025
                 </p>
               </td>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 Assets and code for newsletter
 
 ## Design Colors
-- **Navbar/Header:** Earthy Brown `#4A3B2A` with Cream White text `#FDFBF6`
-- **Buttons:** Primary Blue `#4C7EB0`; hover to Salmon Jump Orange `#FF8F40`
-- **Background:** Cream White `#FDFBF6`
-- **Cards/Panels:** Sky Beige `#E8D8C3` with subtle borders `#d7c4aa`
-- **Links:** Powdered Aqua `#88C3D0` hover to Federal Blue `#041E42`
-- **Data Visuals:** use Yellow, Orange and Aqua to differentiate series
+
+| Purpose | Color Description | HEX | Notes |
+|---------|------------------|-----|-------|
+| **Primary** | Soft Federal Blue | `#4C7EB0` | Main UI color + now used for text |
+| **Secondary** | Warm Sun Yellow | `#FFD966` | Accent and visual highlight |
+| **Accent 1** | Salmon Jump Orange | `#F4A261` | Based on the background hills |
+| **Accent 2** | Soft Sky Beige | `#E8D8C3` | Card backgrounds, sidebars |
+| **Neutral Light** | Cream White | `#FDFBF6` | Page background |
+| **Neutral Dark** | — | *n/a* | Removed in favor of blue |
+| **Highlight** | Powdered Aqua | `#88C3D0` | Water/splash accent color |

--- a/index.html
+++ b/index.html
@@ -10,12 +10,20 @@
   <meta property="og:type" content="website">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
   <style>
-    body{margin:0;font-family:'Inter',Arial,Helvetica,sans-serif;background:#FDFBF6;color:#343434;}
+    :root{
+      --primary:#4C7EB0;
+      --secondary:#FFD966;
+      --accent1:#F4A261;
+      --accent2:#E8D8C3;
+      --neutral-light:#FDFBF6;
+      --highlight:#88C3D0;
+    }
+    body{margin:0;font-family:'Inter',Arial,Helvetica,sans-serif;background:var(--neutral-light);color:#343434;}
     .hero{
       padding:3em 1em;
       text-align:center;
-      background:#4A3B2A;
-      color:#FDFBF6;
+      background:var(--primary);
+      color:var(--neutral-light);
     }
     .hero h1{
       font-family:'Playfair Display',serif;
@@ -23,10 +31,10 @@
     }
     .hero p{margin-bottom:2em;}
     .issue-grid{display:flex;flex-wrap:wrap;gap:20px;justify-content:center;margin-top:2em;}
-    .issue-card{position:relative;flex:0 0 280px;text-decoration:none;color:#FDFBF6;border-radius:8px;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,0.2);transition:transform 0.3s ease, box-shadow 0.3s ease;}
+    .issue-card{position:relative;flex:0 0 280px;text-decoration:none;color:var(--neutral-light);border-radius:8px;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,0.2);transition:transform 0.3s ease, box-shadow 0.3s ease;}
     .issue-card img{width:100%;height:200px;object-fit:cover;display:block;}
     .issue-card span{position:absolute;bottom:0;left:0;right:0;background:rgba(0,0,0,0.6);padding:0.5em;font-weight:bold;font-size:1.25em;text-align:center;}
-    .issue-card:hover{transform:scale(1.05);box-shadow:0 4px 12px rgba(0,0,0,0.3);}
+    .issue-card:hover{transform:scale(1.05);box-shadow:0 4px 12px var(--accent1);}
     @media(max-width:600px){
       .issue-card{flex-basis:100%;}
 


### PR DESCRIPTION
## Summary
- switch all pages to CSS variables for the documented colors
- apply primary blue masthead and navigation styling
- update card colors and highlight text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68470630f9cc8320a330e0e106829116