### PR TITLE
Add side padding without affecting header

### DIFF
--- a/April2025/MarchApril2025Newsletter.html
+++ b/April2025/MarchApril2025Newsletter.html
@@ -31,17 +31,18 @@
 
     .mast{background:var(--primary);border-radius:0 0 16px 16px;}
     .mastInner td{vertical-align:bottom;}
-    .mastInner .titleCell{padding:60px 4%;text-align:center;}
-    .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
+    .mastInner .titleCell{padding:60px 0;text-align:center;}
+    .mastInner .imgCell{width:180px;padding:0 0 12px 0;}
 
     .card{background:#FFFFFF;/* fallback */background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
+    .content{padding:0 36px;}
     .subhead{font-size:21px;font-weight:700;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#000;letter-spacing:0.3px;}
     .menu-bar{
       background:var(--primary);
-      padding:0.5em 1em;
+      padding:0.5em 0;
       position:sticky;
       top:0;
       box-shadow:0 2px 4px rgba(0,0,0,0.15);
@@ -95,7 +96,8 @@
       .imgCol,.txtCol{display:block;width:100%!important;padding:0!important;}
       .txtCol{padding:28px 6%!important;}
       .mastInner .imgCell{display:none!important;}
-      .mastInner .titleCell{padding:40px 6%!important;}
+      .mastInner .titleCell{padding:40px 0!important;}
+      .content{padding:0 6%!important;}
       .menu-items a{flex-basis:100%;}
     }
   </style>
@@ -111,7 +113,7 @@
     </div>
   </nav>
 
-  <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td>
+
 
     <!-- Masthead: robust blue background & inline logo -->
     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);">
@@ -119,10 +121,10 @@
         <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
             <tr>
-              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0 0 12px 4%; width:180px;" valign="bottom">
+              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0 0 12px 0; width:180px;" valign="bottom">
                  <img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/logo/USFWS%20Logo.jpg.webp" alt="USFWS logo" width="180" style="display:block;border:0;width:100%;height:auto;">
               </td>
-              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:60px 4%;" align="center" valign="bottom">
+              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:60px 0;" align="center" valign="bottom">
                 <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:var(--neutral-light);margin:0;">
                   U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter
                 </h1>
@@ -134,10 +136,12 @@
           </table>
         </td>
       </tr>
-    </table>
+      </table>
 
-    <!-- Cle elum netting -->
-    <table role="presentation" width="100%" class="card"><tr>
+      <div class="content">
+
+      <!-- Cle elum netting -->
+      <table role="presentation" width="100%" class="card"><tr>
       <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/April2025/CleElumNetting.JPG" alt="Cle Elum netting"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Cle Elum Netting</h2>
@@ -184,9 +188,10 @@
         <p>This month, we said goodbye to two valued team members. <strong>Blake Hamilton</strong> accepted a Fish Biologist position with Kleinsschmidt Group in Portland, Oregon, and <strong>Brittany Beebe</strong> joined the Oregon Department of Fish and Wildlife in La Grande, OR. Brittany started with the USFWS in November 2022 and served as YRBWEP liaison. She led analysis and reporting of Bull Trout monitoring data from our trap-and-haul program. Blake Hamilton joined the USFWS in November 2023 and led acoustic telemetry work to assess Bull Trout survival and entrainment in Keechelus Reservoir. We’re grateful for their dedication and the time they invested into improving the Yakima Basin.</p>
       </td>
         <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/April2025/Blake_Brittany.jpg" alt="Brittany Beebe and Blake Hamilton"></td>
-    </tr></table>
+      </tr></table>
 
-  </td></tr></table>
+      </div>
+
   <script>
     const menuBtn = document.getElementById('menuBtn');
     const menuItems = document.getElementById('menuItems');

--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -31,17 +31,18 @@
 
     .mast{background:var(--primary);border-radius:0 0 16px 16px;}
     .mastInner td{vertical-align:bottom;}
-    .mastInner .titleCell{padding:60px 4%;text-align:center;}
-    .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
+    .mastInner .titleCell{padding:60px 0;text-align:center;}
+    .mastInner .imgCell{width:180px;padding:0 0 12px 0;}
 
     .card{background:#FFFFFF;/* fallback */background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
+    .content{padding:0 36px;}
     .subhead{font-size:21px;font-weight:700;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#000;letter-spacing:0.3px;}
     .menu-bar{
       background:var(--primary);
-      padding:0.5em 1em;
+      padding:0.5em 0;
       position:sticky;
       top:0;
       box-shadow:0 2px 4px rgba(0,0,0,0.15);
@@ -94,7 +95,8 @@
       .imgCol,.txtCol{display:block;width:100%!important;padding:0!important;}
       .txtCol{padding:28px 6%!important;}
       .mastInner .imgCell{display:none!important;}
-      .mastInner .titleCell{padding:40px 6%!important;}
+      .mastInner .titleCell{padding:40px 0!important;}
+      .content{padding:0 6%!important;}
       .menu-items a{flex-basis:100%;}
     }
   </style>
@@ -110,7 +112,7 @@
     </div>
   </nav>
 
-  <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td>
+
 
     <!-- Masthead -->
     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);">
@@ -118,10 +120,10 @@
         <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
             <tr>
-              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0 0 12px 4%; width:180px;" valign="bottom">
+              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0 0 12px 0; width:180px;" valign="bottom">
                 <img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/logo/USFWS%20Logo.jpg.webp" alt="USFWS logo" width="180" style="display:block;border:0;width:100%;height:auto;">
               </td>
-              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:60px 4%;" align="center" valign="bottom">
+              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:60px 0;" align="center" valign="bottom">
                 <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:var(--neutral-light);margin:0;">
                   U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter
                 </h1>
@@ -133,9 +135,11 @@
           </table>
         </td>
       </tr>
-    </table>
+      </table>
 
-    <!-- Acoustic Monitoring -->
+      <div class="content">
+
+      <!-- Acoustic Monitoring -->
     <table role="presentation" width="100%" class="card"><tr>
       <td class="imgCol"><img src="Acoustic_DEC.png" alt="Bull Trout map in Keechelus"></td>
       <td class="txtCol pad">
@@ -182,9 +186,10 @@
         <p class="subhead">Antennas Off for the Winter</p>
         <p>PIT antennas in Big, Little, and Tucker creeks were shut down December&nbsp;4. The Taneum Creek site remains active. Kittitas Reclamation District diverts canal water to these streams to bolster flows for fish, and our monitoring assesses how many benefit. In 2024 the KRD sites logged <strong>768</strong> individual fish&mdash;including <strong>512</strong> O.&nbsp;mykiss, <strong>246</strong> Coho, and <strong>10</strong> Chinook.</p>
       </td>
-    </tr></table>
+      </tr></table>
 
-  </td></tr></table>
+      </div>
+
   <script>
     const menuBtn = document.getElementById('menuBtn');
     const menuItems = document.getElementById('menuItems');

--- a/May2025/May2025Newsletter.html
+++ b/May2025/May2025Newsletter.html
@@ -31,17 +31,18 @@
 
     .mast{background:var(--primary);border-radius:0 0 16px 16px;}
     .mastInner td{vertical-align:bottom;}
-    .mastInner .titleCell{padding:60px 4%;text-align:center;}
-    .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
+    .mastInner .titleCell{padding:60px 0;text-align:center;}
+    .mastInner .imgCell{width:180px;padding:0 0 12px 0;}
 
     .card{background:#FFFFFF;/* fallback */background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
+    .content{padding:0 36px;}
     .subhead{font-size:21px;font-weight:700;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#000;letter-spacing:0.3px;}
     .menu-bar{
       background:var(--primary);
-      padding:0.5em 1em;
+      padding:0.5em 0;
       position:sticky;
       top:0;
       box-shadow:0 2px 4px rgba(0,0,0,0.15);
@@ -95,7 +96,8 @@
       .imgCol,.txtCol{display:block;width:100%!important;padding:0!important;}
       .txtCol{padding:28px 6%!important;}
       .mastInner .imgCell{display:none!important;}
-      .mastInner .titleCell{padding:40px 6%!important;}
+      .mastInner .titleCell{padding:40px 0!important;}
+      .content{padding:0 6%!important;}
       .menu-items a{flex-basis:100%;}
     }
   </style>
@@ -111,7 +113,7 @@
     </div>
   </nav>
 
-  <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td>
+
 
     <!-- Masthead: robust blue background & inline logo -->
     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);">
@@ -119,10 +121,10 @@
         <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
             <tr>
-              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0 0 12px 4%; width:180px;" valign="bottom">
+              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0 0 12px 0; width:180px;" valign="bottom">
                 <img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/logo/USFWS%20Logo.jpg.webp" alt="USFWS logo" width="180" style="display:block;border:0;width:100%;height:auto;">
               </td>
-              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:60px 4%;" align="center" valign="bottom">
+              <td bgcolor="#4c7eb0" style="background:var(--primary); padding:60px 0;" align="center" valign="bottom">
                 <h1 style="font-size:44px;line-height:50px;font-weight:700;letter-spacing:0.6px;color:var(--neutral-light);margin:0;">
                   U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter
                 </h1>
@@ -134,10 +136,11 @@
           </table>
         </td>
       </tr>
-    </table>
+      </table>
 
-  
-    <!-- eDNA Sampling at Toppenish NWR -->
+      <div class="content">
+
+      <!-- eDNA Sampling at Toppenish NWR -->
     <table role="presentation" width="100%" class="card"><tr>
       <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/May2025/eDNA.jpg" alt="Collecting eDNA sample at Toppenish NWR"></td>
       <td class="txtCol pad">
@@ -175,9 +178,11 @@
         <p>Staff recently met with Yakama Nation Biologist Zack Mays to discuss installing a new PIT antenna below Tieton Dam. The goal of this array is to monitor potential Bull Trout entrainment. While entrainment is known to occur at the dam, its true extent remains unclear. During a dewatering event in 2005, 37 Bull Trout were captured in the stilling basin. Despite numerous trap-and-haul efforts only 2 Bull Trout have been captured since 2020, underscoring the need for better detection tools.</p>
       </td>
       <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/May2025/Tieton_Dam.jpg" alt="Tieton Dam"></td>
-    </tr></table>
+      </tr></table>
 
-  </td></tr></table>
+      </div>
+
+
   <script>
     const menuBtn = document.getElementById('menuBtn');
     const menuItems = document.getElementById('menuItems');


### PR DESCRIPTION
## Summary
- remove outer background table so the header touches the page edges
- keep cards wrapped in `.content` for consistent side padding

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_684726945f6883209f79574c5c0131f3