### PR TITLE
Ensure masthead spans full width

### DIFF
--- a/April2025/MarchApril2025Newsletter.html
+++ b/April2025/MarchApril2025Newsletter.html
@@ -19,7 +19,7 @@
       --neutral-light:#d9f3ff;
       --highlight:#000000;
     }
-    body{margin:0;padding:0 36px;background:#a0acbd;font-family:'Inter',Arial,Helvetica,sans-serif;color:#000000;}
+    body{margin:0;background:#a0acbd;font-family:'Inter',Arial,Helvetica,sans-serif;color:#000000;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
@@ -87,6 +87,8 @@
 
     .menu-items.show{display:flex;}
 
+    .page{padding:0 36px;}
+
 
     @media only screen and (max-width:720px){
       h1{font-size:34px;line-height:40px;}
@@ -114,7 +116,7 @@
   <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td>
 
     <!-- Masthead: robust blue background & inline logo -->
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);" class="mast">
       <tr>
         <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
@@ -135,6 +137,8 @@
         </td>
       </tr>
     </table>
+
+    <div class="page">
 
     <!-- Cle elum netting -->
     <table role="presentation" width="100%" class="card"><tr>
@@ -185,6 +189,8 @@
       </td>
         <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/April2025/Blake_Brittany.jpg" alt="Brittany Beebe and Blake Hamilton"></td>
     </tr></table>
+
+    </div>
 
   </td></tr></table>
   <script>

--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -19,7 +19,7 @@
       --neutral-light:#d9f3ff;
       --highlight:#000000;
     }
-    body{margin:0;padding:0 36px;background:#a0acbd;font-family:'Inter',Arial,Helvetica,sans-serif;color:#000000;}
+    body{margin:0;background:#a0acbd;font-family:'Inter',Arial,Helvetica,sans-serif;color:#000000;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
@@ -87,6 +87,8 @@
 
     .menu-items.show{display:flex;}
 
+    .page{padding:0 36px;}
+
     @media only screen and (max-width:720px){
       h1{font-size:34px;line-height:40px;}
       h2{font-size:24px;line-height:30px;}
@@ -113,7 +115,7 @@
   <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td>
 
     <!-- Masthead -->
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);" class="mast">
       <tr>
         <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
@@ -134,6 +136,8 @@
         </td>
       </tr>
     </table>
+
+    <div class="page">
 
     <!-- Acoustic Monitoring -->
     <table role="presentation" width="100%" class="card"><tr>
@@ -183,6 +187,8 @@
         <p>PIT antennas in Big, Little, and Tucker creeks were shut down December&nbsp;4. The Taneum Creek site remains active. Kittitas Reclamation District diverts canal water to these streams to bolster flows for fish, and our monitoring assesses how many benefit. In 2024 the KRD sites logged <strong>768</strong> individual fish&mdash;including <strong>512</strong> O.&nbsp;mykiss, <strong>246</strong> Coho, and <strong>10</strong> Chinook.</p>
       </td>
     </tr></table>
+
+    </div>
 
   </td></tr></table>
   <script>

--- a/May2025/May2025Newsletter.html
+++ b/May2025/May2025Newsletter.html
@@ -19,7 +19,7 @@
       --neutral-light:#d9f3ff;
       --highlight:#000000;
     }
-    body{margin:0;padding:0 36px;background:#a0acbd;font-family:'Inter',Arial,Helvetica,sans-serif;color:#000000;}
+    body{margin:0;background:#a0acbd;font-family:'Inter',Arial,Helvetica,sans-serif;color:#000000;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
@@ -87,6 +87,8 @@
 
     .menu-items.show{display:flex;}
 
+    .page{padding:0 36px;}
+
 
     @media only screen and (max-width:720px){
       h1{font-size:34px;line-height:40px;}
@@ -114,7 +116,7 @@
   <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td>
 
     <!-- Masthead: robust blue background & inline logo -->
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);" class="mast">
       <tr>
         <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
           <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
@@ -136,7 +138,8 @@
       </tr>
     </table>
 
-  
+    <div class="page">
+
     <!-- eDNA Sampling at Toppenish NWR -->
     <table role="presentation" width="100%" class="card"><tr>
       <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/May2025/eDNA.jpg" alt="Collecting eDNA sample at Toppenish NWR"></td>
@@ -176,6 +179,8 @@
       </td>
       <td class="imgCol"><img src="https://raw.githubusercontent.com/Conman515/Newsletter/main/May2025/Tieton_Dam.jpg" alt="Tieton Dam"></td>
     </tr></table>
+
+    </div>
 
   </td></tr></table>
   <script>


### PR DESCRIPTION
## Summary
- stop wrapping masthead in the `.page` container
- open the padded wrapper after the masthead so header sections reach the edges
- mark each masthead table with the existing `.mast` class

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847309f42488320baa8d5de7806c220