### PR TITLE
Add animations to pages and navigation

### DIFF
--- a/April2025/MarchApril2025Newsletter.html
+++ b/April2025/MarchApril2025Newsletter.html
@@ -19,7 +19,9 @@
       --neutral-light:#d9f3ff;
       --highlight:#000000;
     }
-    body{margin:0;background:#a0acbd;font-family:'Newsreader',serif;color:#000000;}
+    body{margin:0;background:#a0acbd;font-family:'Newsreader',serif;color:#000000;opacity:0;transition:opacity 0.5s ease-in-out;}
+    body.fade-in{opacity:1;}
+    body.fade-out{opacity:0;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
@@ -57,6 +59,7 @@
       background:none;
       border:none;
       cursor:pointer;
+      transition:transform 0.2s;
     }
     .home-btn{
       font-size:33.6px;
@@ -67,6 +70,7 @@
       margin-left:0.5em;
       display:flex;
       align-items:center;
+      transition:transform 0.2s;
     }
     .home-btn svg{
       width:1em;
@@ -93,11 +97,13 @@
       line-height:1.3;
       font-weight:500;
       margin:0.25em 0;
+      transition:transform 0.2s;
     }
     .menu-btn:hover,
     .home-btn:hover,
     .menu-items a:hover {
       color: var(--accent1);
+      transform: scale(1.1);
     }
 
     .menu-items.show{display:flex;}
@@ -222,6 +228,19 @@
     menuBtn.addEventListener('click', function(){
       menuItems.classList.toggle('show');
       menuBtn.innerHTML = menuItems.classList.contains('show') ? '&#10006;' : '&#9776;';
+    });
+    document.addEventListener('DOMContentLoaded', function(){
+      document.body.classList.add('fade-in');
+      document.querySelectorAll('a').forEach(function(link){
+        const href = link.getAttribute('href');
+        if(!href || href.startsWith('#') || link.target === '_blank') return;
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          document.body.classList.remove('fade-in');
+          document.body.classList.add('fade-out');
+          setTimeout(function(){ window.location.href = href; }, 300);
+        });
+      });
     });
   </script>
 </body>

--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -19,7 +19,9 @@
       --neutral-light:#d9f3ff;
       --highlight:#000000;
     }
-    body{margin:0;background:#a0acbd;font-family:'Newsreader',serif;color:#000000;}
+    body{margin:0;background:#a0acbd;font-family:'Newsreader',serif;color:#000000;opacity:0;transition:opacity 0.5s ease-in-out;}
+    body.fade-in{opacity:1;}
+    body.fade-out{opacity:0;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
@@ -57,6 +59,7 @@
       background:none;
       border:none;
       cursor:pointer;
+      transition:transform 0.2s;
     }
     .home-btn{
       font-size:33.6px;
@@ -67,6 +70,7 @@
       margin-left:0.5em;
       display:flex;
       align-items:center;
+      transition:transform 0.2s;
     }
     .home-btn svg{
       width:1em;
@@ -93,11 +97,13 @@
       line-height:1.3;
       font-weight:500;
       margin:0.25em 0;
+      transition:transform 0.2s;
     }
     .menu-btn:hover,
     .home-btn:hover,
     .menu-items a:hover {
       color: var(--accent1);
+      transform: scale(1.1);
     }
 
     .menu-items.show{display:flex;}
@@ -220,6 +226,19 @@
     menuBtn.addEventListener('click', function(){
       menuItems.classList.toggle('show');
       menuBtn.innerHTML = menuItems.classList.contains('show') ? '&#10006;' : '&#9776;';
+    });
+    document.addEventListener('DOMContentLoaded', function(){
+      document.body.classList.add('fade-in');
+      document.querySelectorAll('a').forEach(function(link){
+        const href = link.getAttribute('href');
+        if(!href || href.startsWith('#') || link.target === '_blank') return;
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          document.body.classList.remove('fade-in');
+          document.body.classList.add('fade-out');
+          setTimeout(function(){ window.location.href = href; }, 300);
+        });
+      });
     });
   </script>
 </body>

--- a/May2025/May2025Newsletter.html
+++ b/May2025/May2025Newsletter.html
@@ -19,7 +19,9 @@
       --neutral-light:#d9f3ff;
       --highlight:#000000;
     }
-    body{margin:0;background:#a0acbd;font-family:'Newsreader',serif;color:#000000;}
+    body{margin:0;background:#a0acbd;font-family:'Newsreader',serif;color:#000000;opacity:0;transition:opacity 0.5s ease-in-out;}
+    body.fade-in{opacity:1;}
+    body.fade-out{opacity:0;}
     *,*::before,*::after{box-sizing:border-box;}
     table{border-collapse:collapse!important;width:100%;}
     img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
@@ -57,6 +59,7 @@
       background:none;
       border:none;
       cursor:pointer;
+      transition:transform 0.2s;
     }
     .home-btn{
       font-size:33.6px;
@@ -67,6 +70,7 @@
       margin-left:0.5em;
       display:flex;
       align-items:center;
+      transition:transform 0.2s;
     }
     .home-btn svg{
       width:1em;
@@ -93,11 +97,13 @@
       line-height:1.3;
       font-weight:500;
       margin:0.25em 0;
+      transition:transform 0.2s;
     }
     .menu-btn:hover,
     .home-btn:hover,
     .menu-items a:hover {
       color: var(--accent1);
+      transform: scale(1.1);
     }
 
     .menu-items.show{display:flex;}
@@ -212,6 +218,19 @@
     menuBtn.addEventListener('click', function(){
       menuItems.classList.toggle('show');
       menuBtn.innerHTML = menuItems.classList.contains('show') ? '&#10006;' : '&#9776;';
+    });
+    document.addEventListener('DOMContentLoaded', function(){
+      document.body.classList.add('fade-in');
+      document.querySelectorAll('a').forEach(function(link){
+        const href = link.getAttribute('href');
+        if(!href || href.startsWith('#') || link.target === '_blank') return;
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          document.body.classList.remove('fade-in');
+          document.body.classList.add('fade-out');
+          setTimeout(function(){ window.location.href = href; }, 300);
+        });
+      });
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,11 @@
       align-items: center;
       justify-content: center;
       text-align: center;
+      opacity: 0;
+      transition: opacity 0.5s ease-in-out;
     }
+    body.fade-in { opacity: 1; }
+    body.fade-out { opacity: 0; }
       .hero {
         color: #000;
       }
@@ -65,7 +69,7 @@
     }
     .cta:hover {
       background: #e09f1f;
-      transform: translateY(-3px);
+      transform: translateY(-3px) scale(1.05);
     }
     @media (max-width: 600px) {
       .title {
@@ -86,5 +90,20 @@
     </h1>
     <a href="newsletter.html" class="cta">Enter</a>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      document.body.classList.add('fade-in');
+      document.querySelectorAll('a').forEach(function(link){
+        const href = link.getAttribute('href');
+        if(!href || href.startsWith('#') || link.target === '_blank') return;
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          document.body.classList.remove('fade-in');
+          document.body.classList.add('fade-out');
+          setTimeout(function(){ window.location.href = href; }, 300);
+        });
+      });
+    });
+  </script>
 </body>
 </html>

--- a/newsletter.html
+++ b/newsletter.html
@@ -18,7 +18,9 @@
       --neutral-light:#d9f3ff;
       --highlight:#000000;
     }
-    body{margin:0;font-family:'Newsreader',serif;background:#a0acbd;color:#000000;}
+    body{margin:0;font-family:'Newsreader',serif;background:#a0acbd;color:#000000;opacity:0;transition:opacity 0.5s ease-in-out;}
+    body.fade-in{opacity:1;}
+    body.fade-out{opacity:0;}
     .hero{
       padding:3em 1em;
       text-align:center;
@@ -81,5 +83,20 @@
       </a>
     </div>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      document.body.classList.add('fade-in');
+      document.querySelectorAll('a').forEach(function(link){
+        const href = link.getAttribute('href');
+        if(!href || href.startsWith('#') || link.target === '_blank') return;
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          document.body.classList.remove('fade-in');
+          document.body.classList.add('fade-out');
+          setTimeout(function(){ window.location.href = href; }, 300);
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add fade-in/out transitions when navigating between pages
- animate navigation buttons with scale effects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684755c9c4848320bea0fe38fa1edf18