### PR TITLE
Fix hamburger menu height

### DIFF
--- a/April2025/MarchApril2025Newsletter.html
+++ b/April2025/MarchApril2025Newsletter.html
@@ -84,7 +84,7 @@
       top:3em;
       left:0;
       width:200px;
-      height:calc(100% - 3em);
+      height:auto;
       padding:1em;
       gap:0.5em;
       background:var(--primary);

--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -84,7 +84,7 @@
       top:3em;
       left:0;
       width:200px;
-      height:calc(100% - 3em);
+      height:auto;
       padding:1em;
       gap:0.5em;
       background:var(--primary);

--- a/May2025/May2025Newsletter.html
+++ b/May2025/May2025Newsletter.html
@@ -84,7 +84,7 @@
       top:3em;
       left:0;
       width:200px;
-      height:calc(100% - 3em);
+      height:auto;
       padding:1em;
       gap:0.5em;
       background:var(--primary);


### PR DESCRIPTION
## Summary
- make newsletter menus only as tall as the items they contain

## Testing
- `grep -R "calc(100% - 3em)" -n`

------
https://chatgpt.com/codex/tasks/task_e_684757eaba9c8320ab2b61aecafc65c3