### PR TITLE
Add placeholders for upcoming newsletter issues

### DIFF
--- a/newsletter.html
+++ b/newsletter.html
@@ -87,6 +87,30 @@
         <img loading="lazy" src="May2025/eDNA.jpg" alt="May 2025">
         <span>May 2025</span>
       </a>
+      <a class="issue-card" href="#" onclick="return false;">
+        <img loading="lazy" src="https://via.placeholder.com/280x200.png?text=TBA" alt="June 2025">
+        <span>June 2025</span>
+      </a>
+      <a class="issue-card" href="#" onclick="return false;">
+        <img loading="lazy" src="https://via.placeholder.com/280x200.png?text=TBA" alt="July 2025">
+        <span>July 2025</span>
+      </a>
+      <a class="issue-card" href="#" onclick="return false;">
+        <img loading="lazy" src="https://via.placeholder.com/280x200.png?text=TBA" alt="August 2025">
+        <span>August 2025</span>
+      </a>
+      <a class="issue-card" href="#" onclick="return false;">
+        <img loading="lazy" src="https://via.placeholder.com/280x200.png?text=TBA" alt="September 2025">
+        <span>September 2025</span>
+      </a>
+      <a class="issue-card" href="#" onclick="return false;">
+        <img loading="lazy" src="https://via.placeholder.com/280x200.png?text=TBA" alt="October 2025">
+        <span>October 2025</span>
+      </a>
+      <a class="issue-card" href="#" onclick="return false;">
+        <img loading="lazy" src="https://via.placeholder.com/280x200.png?text=TBA" alt="November 2025">
+        <span>November 2025</span>
+      </a>
     </div>
   </div>
   <div class="dashboard">


### PR DESCRIPTION
## Summary
- add empty cards for June through November 2025 on the newsletter page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68475f8e928c8320a56b4d0085dd4f65