### PR TITLE
Add data page for metrics

### DIFF
--- a/data.html
+++ b/data.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Program Metrics Dashboard</title>
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    :root{
+      --primary:#4c7eb0;
+      --secondary:#FFFFFF;
+      --accent1:#e09f1f;
+      --accent2:#FFFFFF;
+      --neutral-light:#d9f3ff;
+      --highlight:#000000;
+    }
+    body{margin:0;font-family:'Newsreader',serif;background:#a0acbd;color:#000000;opacity:0;transition:opacity 0.5s ease-in-out;}
+    body.fade-in{opacity:1;}
+    body.fade-out{opacity:0;}
+    .hero{padding:3em 1em;text-align:center;background:var(--primary);color:var(--neutral-light);}
+    .hero a{color:var(--neutral-light);} 
+    .dashboard{background:var(--secondary);padding:2em 1em;text-align:center;}
+    .dashboard-grid{display:flex;flex-wrap:wrap;justify-content:center;gap:20px;margin-top:1em;}
+    .dashboard-card{background:var(--neutral-light);border-radius:8px;padding:1em 2em;min-width:200px;box-shadow:0 2px 6px rgba(0,0,0,0.2);}
+    .dashboard-card h3{margin:0;font-size:1.1em;color:var(--highlight);}
+    .dashboard-card p{margin:0.5em 0 0;font-size:2.5em;color:var(--primary);font-weight:700;}
+    .charts{display:flex;flex-wrap:wrap;justify-content:center;gap:20px;padding:2em 1em;}
+    .charts canvas{max-width:400px;width:100%;background:var(--secondary);border-radius:8px;box-shadow:0 2px 6px rgba(0,0,0,0.2);}
+    @media(max-width:600px){
+      .dashboard-card{flex-basis:100%;}
+      .charts canvas{flex-basis:100%;}
+    }
+  </style>
+</head>
+<body>
+  <div class="hero">
+    <h1>Program Metrics Dashboard</h1>
+    <p><a href="newsletter.html">Back to Newsletter</a></p>
+  </div>
+  <div class="dashboard">
+    <h2>Program Metrics</h2>
+    <div class="dashboard-grid">
+      <div class="dashboard-card">
+        <h3>Number of Bull Trout Captured</h3>
+        <p>274</p>
+      </div>
+      <div class="dashboard-card">
+        <h3>Unique PIT Tags Detected</h3>
+        <p>7,151</p>
+      </div>
+      <div class="dashboard-card">
+        <h3>eDNA Samples Collected</h3>
+        <p>86</p>
+      </div>
+    </div>
+  </div>
+  <div class="charts">
+    <canvas id="barChart" width="400" height="200"></canvas>
+    <canvas id="lineChart" width="400" height="200"></canvas>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      document.body.classList.add('fade-in');
+      document.querySelectorAll('a').forEach(function(link){
+        const href = link.getAttribute('href');
+        if(!href || href.startsWith('#') || link.target === '_blank') return;
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          document.body.classList.remove('fade-in');
+          document.body.classList.add('fade-out');
+          setTimeout(function(){ window.location.href = href; }, 300);
+        });
+      });
+
+      const barCtx = document.getElementById('barChart').getContext('2d');
+      new Chart(barCtx, {
+        type: 'bar',
+        data: {
+          labels: ['Bull Trout', 'PIT Tags', 'eDNA'],
+          datasets: [{
+            label: 'Count',
+            data: [274, 7151, 86],
+            backgroundColor: ['rgba(76,126,176,0.7)','rgba(224,159,31,0.7)','rgba(100,100,100,0.7)']
+          }]
+        },
+        options: {responsive: true}
+      });
+
+      const lineCtx = document.getElementById('lineChart').getContext('2d');
+      new Chart(lineCtx, {
+        type: 'line',
+        data: {
+          labels: ['2022','2023','2024','2025'],
+          datasets: [{
+            label: 'Bull Trout Captures',
+            data: [150,200,225,274],
+            fill: false,
+            borderColor: 'rgba(76,126,176,0.7)'
+          }]
+        },
+        options: {responsive: true}
+      });
+    });
+  </script>
+</body>
+</html>

--- a/newsletter.html
+++ b/newsletter.html
@@ -56,17 +56,21 @@
       text-align:center;
     }
     .issue-card:hover{transform:scale(1.05);box-shadow:0 4px 12px var(--accent1);}
-    .dashboard{background:var(--secondary);padding:2em 1em;text-align:center;}
-    .dashboard-grid{display:flex;flex-wrap:wrap;justify-content:center;gap:20px;margin-top:1em;}
-    .dashboard-card{background:var(--neutral-light);border-radius:8px;padding:1em 2em;min-width:200px;box-shadow:0 2px 6px rgba(0,0,0,0.2);}
-    .dashboard-card h3{margin:0;font-size:1.1em;color:var(--highlight);}
-    .dashboard-card p{margin:0.5em 0 0;font-size:2.5em;color:var(--primary);font-weight:700;}
+    .metrics-link{
+      display:inline-block;
+      margin-top:2em;
+      padding:0.75em 1.5em;
+      background:var(--accent1);
+      color:var(--neutral-light);
+      text-decoration:none;
+      border-radius:4px;
+      font-weight:700;
+    }
     @media(max-width:600px){
       .issue-card{flex-basis:100%;}
       .issue-card span{font-size:1.2em;}
       .hero h1{font-size:36px;}
       .hero p{font-size:19.2px;}
-      .dashboard-card{flex-basis:100%;}
     }
   </style>
 </head>
@@ -88,23 +92,7 @@
         <span>May 2025</span>
       </a>
     </div>
-  </div>
-  <div class="dashboard">
-    <h2>Program Metrics</h2>
-    <div class="dashboard-grid">
-      <div class="dashboard-card">
-        <h3>Number of Bull Trout Captured</h3>
-        <p>274</p>
-      </div>
-      <div class="dashboard-card">
-        <h3>Unique PIT Tags Detected</h3>
-        <p>7,151</p>
-      </div>
-      <div class="dashboard-card">
-        <h3>eDNA Samples Collected</h3>
-        <p>86</p>
-      </div>
-    </div>
+    <a class="metrics-link" href="data.html">Program Metrics Dashboard</a>
   </div>
   <script>
     document.addEventListener('DOMContentLoaded', function(){


### PR DESCRIPTION
## Summary
- extract metrics dashboard from `newsletter.html`
- add a button linking to a new metrics page
- create `data.html` with dashboard numbers and sample graphs using Chart.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684773a67b788320be04ab78c3855f52