### PR TITLE
Update footer links color

### DIFF
--- a/April2025/MarchApril2025Newsletter.html
+++ b/April2025/MarchApril2025Newsletter.html
@@ -126,6 +126,7 @@
       .menu-items a{flex-basis:100%;}
     }
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
   </style>
 </head>
 <body>

--- a/DecJan2025/DecJan2025Newsletter.html
+++ b/DecJan2025/DecJan2025Newsletter.html
@@ -125,6 +125,7 @@
       .menu-items a{flex-basis:100%;}
     }
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
   </style>
 </head>
 <body>

--- a/May2025/May2025Newsletter.html
+++ b/May2025/May2025Newsletter.html
@@ -126,6 +126,7 @@
       .menu-items a{flex-basis:100%;}
     }
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
   </style>
 </head>
 <body>

--- a/data.html
+++ b/data.html
@@ -47,6 +47,7 @@
       .charts canvas{flex-basis:100%;}
     }
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
   </style>
 </head>
 <body>

--- a/home.html
+++ b/home.html
@@ -34,6 +34,7 @@
     .card p{margin:0.25em 0 0;font-size:0.9rem;}
     .card:hover{transform:translateY(-5px);box-shadow:0 4px 12px var(--accent1);}
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
       padding:0.5em 0;
       width:100%;
     }
+    footer a{color:orange;}
   </style>
 </head>
 <body>

--- a/newsletter.html
+++ b/newsletter.html
@@ -86,6 +86,7 @@
       .hero p{font-size:19.2px;}
     }
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
   </style>
 </head>
 <body>

--- a/reports.html
+++ b/reports.html
@@ -27,6 +27,7 @@
     .content{text-align:center;padding:2em;}
     a{color:#4c7eb0;}
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- change footer hyperlinks for Connor Cunningham to orange across all pages

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68477ebfd5e48320825f3ea8779a8c30