### PR TITLE
Remove USFWS navbar logo

### DIFF
--- a/data.html
+++ b/data.html
@@ -70,7 +70,6 @@
 <body>
   <header>
     <div class="logo">
-      <img src="logo/USFWS Logo.jpg.webp" alt="USFWS logo">
       The Leaky Wader
     </div>
     <div class="hamburger" id="hamburger">

--- a/home.html
+++ b/home.html
@@ -58,7 +58,6 @@
 <body>
   <header>
     <div class="logo">
-      <img src="logo/USFWS Logo.jpg.webp" alt="USFWS logo">
       The Leaky Wader
     </div>
     <!-- navigation removed on the home page -->

--- a/newsletter.html
+++ b/newsletter.html
@@ -110,7 +110,6 @@
 <body>
   <header>
     <div class="logo">
-      <img src="logo/USFWS Logo.jpg.webp" alt="USFWS logo">
       The Leaky Wader
     </div>
     <div class="hamburger" id="hamburger">

--- a/reports.html
+++ b/reports.html
@@ -63,7 +63,6 @@
 <body>
   <header>
     <div class="logo">
-      <img src="logo/USFWS Logo.jpg.webp" alt="USFWS logo">
       The Leaky Wader
     </div>
     <div class="hamburger" id="hamburger">


### PR DESCRIPTION
## Summary
- strip USFWS logo from the navbar on main pages
- keep report images in the reports page

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684892d8a04c83208ef78e9f0775aea3