### PR TITLE
Enlarge cards on home screen

### DIFF
--- a/home.html
+++ b/home.html
@@ -46,14 +46,14 @@
     main{flex:1;text-align:center;padding:2em 1em;}
     main h1{font-size:2.5rem;margin-top:1em;}
     .card-container{display:flex;flex-wrap:wrap;justify-content:center;gap:20px;margin-top:2em;}
-    .card{background:var(--neutral-light);color:var(--primary);text-decoration:none;border-radius:8px;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,0.2);transition:transform 0.3s ease,box-shadow 0.3s ease;width:220px;padding:1em;}
-    .card img{width:100%;height:120px;object-fit:cover;border-radius:4px;}
+      .card{background:var(--neutral-light);color:var(--primary);text-decoration:none;border-radius:8px;overflow:hidden;box-shadow:0 2px 6px rgba(0,0,0,0.2);transition:transform 0.3s ease,box-shadow 0.3s ease;width:300px;padding:1.2em;}
+      .card img{width:100%;height:160px;object-fit:cover;border-radius:4px;}
     .card h2{margin:0.5em 0 0;font-size:1.4rem;}
     .card p{margin:0.25em 0 0;font-size:0.9rem;}
     .card:hover{transform:translateY(-5px);box-shadow:0 4px 12px var(--accent1);}
     @media(max-width:600px){
       .card-container{flex-direction:column;align-items:center;}
-      .card{width:100%;max-width:300px;}
+        .card{width:100%;max-width:350px;}
     }
     footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
     footer a{color:orange;}


### PR DESCRIPTION
## Summary
- increase the width and padding of home page cards
- raise card image height
- widen max width on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848a8f59678832086257c73b50a57aa