### PR TITLE
Add June 2025 newsletter

### DIFF
--- a/home.html
+++ b/home.html
@@ -71,7 +71,7 @@
     <p>Select a section below to begin.</p>
     <div class="card-container">
       <a href="newsletter.html" class="card">
-        <img src="issues/May2025/steelhead_2.jpg" alt="Newsletter">
+        <img src="assets/logo/usfws-logo.webp" alt="Newsletter">
         <h2>Newsletter</h2>
         <p>Monthly updates and stories</p>
       </a>

--- a/issues/April2025/MarchApril2025Newsletter.html
+++ b/issues/April2025/MarchApril2025Newsletter.html
@@ -141,6 +141,7 @@
       <a href="../DecJan2025/DecJan2025Newsletter.html">Dec - Jan 2025</a>
       <a href="MarchApril2025Newsletter.html">Mar - Apr 2025</a>
       <a href="../May2025/May2025Newsletter.html">May 2025</a>
+      <a href="../June2025/June2025Newsletter.html">June 2025</a>
     </div>
   </nav>
 

--- a/issues/DecJan2025/DecJan2025Newsletter.html
+++ b/issues/DecJan2025/DecJan2025Newsletter.html
@@ -140,6 +140,7 @@
       <a href="DecJan2025Newsletter.html">Dec - Jan 2025</a>
       <a href="../April2025/MarchApril2025Newsletter.html">Mar - Apr 2025</a>
       <a href="../May2025/May2025Newsletter.html">May 2025</a>
+      <a href="../June2025/June2025Newsletter.html">June 2025</a>
     </div>
   </nav>
 

--- a/issues/June2025/June2025Newsletter.html
+++ b/issues/June2025/June2025Newsletter.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
-  <title>USFWS - Yakima Newsletter | May 2025</title>
-  <meta property="og:title" content="USFWS - Yakima Newsletter | May 2025">
+  <title>USFWS - Yakima Newsletter | June 2025</title>
+  <meta property="og:title" content="USFWS - Yakima Newsletter | June 2025">
   <meta property="og:description" content="U.S. Fish &amp; Wildlife Service Yakima Newsletter">
   <meta property="og:image" content="../../assets/logo/usfws-logo.webp">
   <meta property="og:type" content="article">
@@ -30,13 +30,11 @@
     h2{font-size:33.6px;line-height:1.3;font-weight:600;color:var(--primary);letter-spacing:0.25px;}
     p,ul,li{margin:16px 0;font-size:21.6px;line-height:1.6;font-weight:400;}
     ul{padding-left:28px;}
-
     .mast{background:var(--primary);border-radius:0 0 16px 16px;width:calc(100% + 36px);margin:0 -18px;}
     .mastInner td{vertical-align:bottom;}
     .mastInner .titleCell{padding:60px 4%;text-align:center;}
     .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
-
-    .card{background:#FFFFFF;/* fallback */background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
+    .card{background:#FFFFFF;background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
@@ -51,66 +49,14 @@
       display:flex;
       align-items:center;
     }
-    .menu-btn{
-      font-size:28.8px;
-      line-height:1.2;
-      font-weight:600;
-      color:var(--neutral-light);
-      background:none;
-      border:none;
-      cursor:pointer;
-      transition:transform 0.2s;
-    }
-    .home-btn{
-      font-size:33.6px;
-      line-height:1.2;
-      font-weight:600;
-      color:var(--neutral-light);
-      text-decoration:none;
-      margin-left:0.5em;
-      display:flex;
-      align-items:center;
-      transition:transform 0.2s;
-    }
-    .home-btn svg{
-      width:1em;
-      height:1em;
-      fill:currentColor;
-    }
-    .menu-items{
-      display:none;
-      flex-direction:column;
-      position:fixed;
-      top:3em;
-      left:0;
-      width:200px;
-      height:auto;
-      padding:1em;
-      gap:0.5em;
-      background:linear-gradient(90deg, var(--primary), var(--accent1));
-      z-index:101;
-    }
-    .menu-items a{
-      color:var(--neutral-light);
-      text-decoration:none;
-      font-size:24px;
-      line-height:1.3;
-      font-weight:500;
-      margin:0.25em 0;
-      transition:transform 0.2s;
-    }
-    .menu-btn:hover,
-    .home-btn:hover,
-    .menu-items a:hover {
-      color: var(--accent1);
-      transform: scale(1.1);
-    }
-
+    .menu-btn{font-size:28.8px;line-height:1.2;font-weight:600;color:var(--neutral-light);background:none;border:none;cursor:pointer;transition:transform 0.2s;}
+    .home-btn{font-size:33.6px;line-height:1.2;font-weight:600;color:var(--neutral-light);text-decoration:none;margin-left:0.5em;display:flex;align-items:center;transition:transform 0.2s;}
+    .home-btn svg{width:1em;height:1em;fill:currentColor;}
+    .menu-items{display:none;flex-direction:column;position:fixed;top:3em;left:0;width:200px;height:auto;padding:1em;gap:0.5em;background:linear-gradient(90deg, var(--primary), var(--accent1));z-index:101;}
+    .menu-items a{color:var(--neutral-light);text-decoration:none;font-size:24px;line-height:1.3;font-weight:500;margin:0.25em 0;transition:transform 0.2s;}
+    .menu-btn:hover,.home-btn:hover,.menu-items a:hover{color:var(--accent1);transform:scale(1.1);}
     .menu-items.show{display:flex;}
-
     .page{padding:0 18px;}
-
-
     @media only screen and (max-width:720px){
       h1{font-size:36px;line-height:1.2;}
       h2{font-size:26.4px;line-height:1.3;}
@@ -140,14 +86,14 @@
     <div id="menuItems" class="menu-items">
       <a href="../DecJan2025/DecJan2025Newsletter.html">Dec - Jan 2025</a>
       <a href="../April2025/MarchApril2025Newsletter.html">Mar - Apr 2025</a>
-      <a href="May2025Newsletter.html">May 2025</a>
-      <a href="../June2025/June2025Newsletter.html">June 2025</a>
+      <a href="../May2025/May2025Newsletter.html">May 2025</a>
+      <a href="June2025Newsletter.html">June 2025</a>
     </div>
   </nav>
 
   <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td class="page">
 
-    <!-- Masthead: robust blue background & inline logo -->
+    <!-- Masthead -->
     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);" class="mast">
       <tr>
         <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
@@ -161,7 +107,7 @@
                   U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter
                 </h1>
                 <p style="margin:12px 0 0;font-size:24px;line-height:1.4;font-weight:400;letter-spacing:0.3px;color:var(--highlight);">
-                  May&nbsp;2025
+                  June&nbsp;2025
                 </p>
               </td>
             </tr>
@@ -172,44 +118,44 @@
 
     <div class="page">
 
-    <!-- eDNA Sampling at Toppenish NWR -->
+    <!-- Bull Trout Found in Gold Creek Pond -->
     <table role="presentation" width="100%" class="card"><tr>
-      <td class="imgCol"><img loading="lazy" src="eDNA.jpg" alt="Collecting eDNA sample at Toppenish NWR"></td>
+      <td class="imgCol"><img loading="lazy" src="../../assets/logo/usfws-logo.webp" alt="Placeholder image"></td>
       <td class="txtCol pad">
-        <h2 style="text-align:center;">eDNA Sampling at Toppenish NWR</h2>
-        <p class="subhead">Detecting Imperiled Mussels</p>
-        <p>Our staff continues to collect environmental DNA (eDNA) samples within Toppenish National Wildlife Refuge. These efforts are focused on measuring the amount of DNA for the four freshwater mussel species in the Yakima Basin:<strong>Western Pearlshell</strong>, <strong>Western Ridged Mussels</strong>, <strong>California Floater</strong>, and <strong>Oregon Floater</strong>. The <strong>Western Ridged Mussel</strong> has been petitioned for listing under the <strong>Endangered Species Act</strong>. Results will be used to better understand the distribution and relative density of these species throughout the lower Yakima Basin and also test an assumption of the sampling that eDNA does not vary by discharge.</p>
+        <h2 style="text-align:center;">Bull Trout Found in Gold Creek Pond</h2>
+        <p class="subhead">First Observation Since 1991</p>
+        <p>On June 4<sup>th</sup>, staff working with the <strong>Kittitas Conservation Trust</strong>, <strong>Yakama Nation</strong>, and <strong>Washington Department of Ecology</strong> captured and relocated an adult <strong>Bull Trout</strong> from Gold Creek Pond. This is the first documented Bull Trout in the pond since <strong>1991</strong>. Snorkel surveys around the pond did not locate additional fish. These findings will guide efforts to refill and restore Gold Creek Pond, which currently diverts groundwater from Gold Creek and creates dry reaches that block Bull Trout migration. Gold Creek is the only spawning tributary for Bull Trout connected to Keechelus Reservoir.</p>
       </td>
     </tr></table>
 
-    <!-- Steelhead Detections at Toppenish PIT Antennas -->
+    <!-- 2024 Trap and Haul Report Finalized -->
     <table role="presentation" width="100%" class="card"><tr>
       <td class="txtCol pad">
-        <h2 style="text-align:center;">Steelhead Detections at Toppenish</h2>
-        <p class="subhead">Adults and Juveniles</p>
-        <p>PIT antennas installed at Toppenish National Wildlife Refuge have recorded <strong>262</strong> Steelhead this season. Of these, <strong>39</strong> were adult spawners returning upstream, and <strong>223</strong> were juveniles migrating to the ocean. These detections have helped identify critical infrastructure and migration paths that may contribute to avoidable mortality, guiding future restoration priorities.</p>
+        <h2 style="text-align:center;">2024 Trap and Haul Report Finalized</h2>
+        <p class="subhead">Comprehensive Management Summary</p>
+        <p>Staff have completed the <strong>2024</strong> trap-and-haul report detailing Bull Trout management activities across the Yakima basin. The report documents <strong>PIT</strong> tag detections, acoustic monitoring results, and survival estimates, providing important context for ongoing conservation work.</p>
       </td>
-      <td class="imgCol"><img loading="lazy" src="steelhead_2.jpg" alt="Steelhead detected at Toppenish"></td>
+      <td class="imgCol"><img loading="lazy" src="../../assets/logo/usfws-logo.webp" alt="Placeholder image"></td>
     </tr></table>
 
-    <!-- Cle Elum Sockeye Trap and Haul Completed -->
+    <!-- Clear Creek and Bumping Dam Operations -->
     <table role="presentation" width="100%" class="card"><tr>
-      <td class="imgCol"><img loading="lazy" src="CleFish.jpg" alt="Cle Elum sockeye smolts"></td>
+      <td class="imgCol"><img loading="lazy" src="../../assets/logo/usfws-logo.webp" alt="Placeholder image"></td>
       <td class="txtCol pad">
-        <h2 style="text-align:center;">Cle Elum Sockeye</h2>
-        <p class="subhead">Trap and Haul</p>
-         <p>The 2025 Cle Elum Sockeye Trap and Haul operation is now complete! This collaborative effort between Yakama Nation, U.S. Fish and Wildlife Service, and the Bureau of Reclamation, successfully captured and transported approximately <strong>63,000</strong> Sockeye smolts around Cle Elum Dam. The operation began on <strong>April 8th</strong> and concluded on <strong>May 16th</strong>. Next year, the <strong>"Helix"</strong> should provide volitional downstream passage for these juveniles which will reduce the stress and handling of these critical smolts.</p>
+        <h2 style="text-align:center;">Clear Creek and Bumping Dam Operations</h2>
+        <p class="subhead">Early Trap and Haul</p>
+        <p>The first Clear Creek Dam trap-and-haul effort of <strong>2025</strong> moved <strong>6</strong> of <strong>10</strong> captured Bull Trout above the dam. Staff also conducted an early-season operation below Bumping Dam. Although no Bull Trout were encountered, it represents the earliest recorded trap-and-haul event at this site and underscores proactive management of Bull Trout populations.</p>
       </td>
     </tr></table>
 
-    <!-- Planning a PIT Array at Tieton Dam -->
+    <!-- PIT Sites Fully Operational -->
     <table role="presentation" width="100%" class="card"><tr>
       <td class="txtCol pad">
-        <h2 style="text-align:center;">PIT Array at Tieton Dam</h2>
-        <p class="subhead">Monitoring Bull Trout Entrainment</p>
-        <p>Staff recently met with Yakama Nation Biologist Zack Mays to discuss installing a new PIT antenna below Tieton Dam. The goal of this array is to monitor potential Bull Trout entrainment. While entrainment is known to occur at the dam, its true extent remains unclear. During a dewatering event in 2005, 37 Bull Trout were captured in the stilling basin. Despite numerous trap-and-haul efforts only 2 Bull Trout have been captured since 2020, underscoring the need for better detection tools.</p>
+        <h2 style="text-align:center;">PIT Sites Fully Operational</h2>
+        <p class="subhead">Basinwide Monitoring</p>
+        <p>PIT tag monitoring sites throughout the Yakima basin are online and actively collecting data. Arrays cover spawning tributaries associated with Rimrock, Kachess, and Keechelus reservoirs, the Schaake restoration project, supplementation streams managed by the Kittitas Reclamation District, Toppenish National Wildlife Refuge, and other locations near Bureau of Reclamation infrastructure.</p>
       </td>
-      <td class="imgCol"><img loading="lazy" src="Tieton_Dam.jpg" alt="Tieton Dam"></td>
+      <td class="imgCol"><img loading="lazy" src="../../assets/logo/usfws-logo.webp" alt="Placeholder image"></td>
     </tr></table>
 
     </div>

--- a/newsletter.html
+++ b/newsletter.html
@@ -139,6 +139,10 @@
         <img loading="lazy" src="issues/May2025/eDNA.jpg" alt="May 2025">
         <span>May 2025</span>
       </a>
+      <a class="issue-card" href="issues/June2025/June2025Newsletter.html">
+        <img loading="lazy" src="assets/logo/usfws-logo.webp" alt="June 2025">
+        <span>June 2025</span>
+      </a>
     </div>
   </main>
   <script>


### PR DESCRIPTION
## Summary
- add June 2025 newsletter issue with placeholder images and new article text
- update navigation in previous issues to link to the new issue
- include June newsletter on the newsletter index page
- point home page newsletter card at the latest issue
- remove binary placeholder image

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d53e3b0ec8320b694e30ac14e09a4