### PR TITLE
Remove subheadings from June newsletter

### DIFF
--- a/issues/June2025/June2025Newsletter.html
+++ b/issues/June2025/June2025Newsletter.html
@@ -38,7 +38,6 @@
     .pad{padding:38px 5%;}
     .imgCol{width:42%;vertical-align:top;}
     .txtCol{width:58%;vertical-align:top;padding-left:34px;}
-    .subhead{font-size:24px;font-weight:500;line-height:1.5;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#000;letter-spacing:0.3px;font-family:Helvetica,Arial,sans-serif;}
     .menu-bar{
       background:linear-gradient(90deg, var(--primary), var(--accent1));
       padding:0.5em 1em;
@@ -61,7 +60,6 @@
       h1{font-size:36px;line-height:1.2;}
       h2{font-size:26.4px;line-height:1.3;}
       p,ul,li{font-size:19.2px;}
-      .subhead{font-size:21.6px;line-height:1.5;}
       .menu-btn{font-size:26.4px;}
       .home-btn{font-size:28.8px;}
       .menu-items a{font-size:21.6px;}
@@ -123,7 +121,6 @@
       <td class="imgCol"><img loading="lazy" src="Gold-Creek-Pond.jpg" alt="Gold Creek Pond"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Bull Trout Found in Gold Creek Pond</h2>
-        <p class="subhead">First Observation Since 1991</p>
         <p>On June 4<sup>th</sup>, staff working with the <strong>Kittitas Conservation Trust</strong>, <strong>Yakama Nation</strong>, and <strong>Washington Department of Ecology</strong> captured and relocated an adult <strong>Bull Trout</strong> from Gold Creek Pond. This is the first documented Bull Trout in the pond since <strong>1991</strong>. Snorkel surveys around the pond did not locate additional fish. These findings will guide efforts to refill and restore Gold Creek Pond, which currently diverts groundwater from Gold Creek and creates dry reaches that block Bull Trout migration. Gold Creek is the only spawning tributary for Bull Trout connected to Keechelus Reservoir.</p>
       </td>
     </tr></table>
@@ -132,7 +129,6 @@
     <table role="presentation" width="100%" class="card"><tr>
       <td class="txtCol pad">
         <h2 style="text-align:center;">2024 Trap and Haul Report Finalized</h2>
-        <p class="subhead">Comprehensive Management Summary</p>
         <p>Staff have completed the <strong>2024</strong> trap-and-haul report detailing Bull Trout management activities across the Yakima basin. The report documents <strong>PIT</strong> tag detections, acoustic monitoring results, and survival estimates, providing important context for ongoing conservation work.</p>
       </td>
       <td class="imgCol"><img loading="lazy" src="../../assets/reports/2024-th.png" alt="2024 Trap and Haul Report cover"></td>
@@ -143,7 +139,6 @@
       <td class="imgCol"><img loading="lazy" src="IMG_5893.JPG" alt="Clear Creek operations"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Clear Creek and Bumping Dam Operations</h2>
-        <p class="subhead">Early Trap and Haul</p>
         <p>The first Clear Creek Dam trap-and-haul effort of <strong>2025</strong> moved <strong>6</strong> of <strong>10</strong> captured Bull Trout above the dam. Staff also conducted an early-season operation below Bumping Dam. Although no Bull Trout were encountered, it represents the earliest recorded trap-and-haul event at this site and underscores proactive management of Bull Trout populations.</p>
       </td>
     </tr></table>
@@ -152,7 +147,6 @@
     <table role="presentation" width="100%" class="card"><tr>
       <td class="txtCol pad">
         <h2 style="text-align:center;">PIT Sites Fully Operational</h2>
-        <p class="subhead">Basinwide Monitoring</p>
         <p>PIT tag monitoring sites throughout the Yakima basin are online and actively collecting data. Arrays cover spawning tributaries associated with Rimrock, Kachess, and Keechelus reservoirs, the Schaake restoration project, supplementation streams managed by the Kittitas Reclamation District, Toppenish National Wildlife Refuge, and other locations near Bureau of Reclamation infrastructure.</p>
       </td>
       <td class="imgCol"><img loading="lazy" src="Snake-Creek-PIT-antenna-steelhead-monitoring-at-toppenish-national-wildlife-refuge-mid-columbia-fish-and-wildlife-conservation-office-yakima-suboffice.jpg" alt="Snake Creek PIT antenna"></td>


### PR DESCRIPTION
## Summary
- remove `.subhead` CSS and subheading paragraphs in June 2025 newsletter

## Testing
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da9ccf5448320abb51b05b7f8f660