### PR TITLE
Add SCA interns section to June newsletter

### DIFF
--- a/issues/June2025/June2025Newsletter.html
+++ b/issues/June2025/June2025Newsletter.html
@@ -162,6 +162,15 @@
       <td class="imgCol"><img loading="lazy" src="Snake-Creek-PIT-antenna-steelhead-monitoring-at-toppenish-national-wildlife-refuge-mid-columbia-fish-and-wildlife-conservation-office-yakima-suboffice.jpg" alt="Snake Creek PIT antenna"></td>
     </tr></table>
 
+    <!-- Student Conservation Association Interns -->
+    <table role="presentation" width="100%" class="card"><tr>
+      <td class="imgCol"><img loading="lazy" src="Lauren.jpg" alt="Emma Meyer and Lauren Knitter"></td>
+      <td class="txtCol pad">
+        <h2 style="text-align:center;">SCA Interns Join the Team</h2>
+        <p>We are excited to welcome <strong>Emma Meyer</strong> (Left) and <strong>Lauren Knitter</strong> (Right) to our team as summer interns through the <strong>Student Conservation Association (SCA)</strong>, a program dedicated to providing youth and young adults with hands-on experience in environmental conservation. Emma graduated from the <strong>University of Washington</strong> with a degree in <strong>Aquatic and Fisheries Sciences</strong>, and Lauren graduated from <strong>James Madison University</strong> with a degree in <strong>Integrated Science and Technology</strong>. Throughout the summer, Emma and Lauren will support our team and collaborators on a variety of critical projects, gaining valuable real-world experience that will help launch their careers in conservation.</p>
+      </td>
+    </tr></table>
+
     </div>
 
   </td></tr></table>


### PR DESCRIPTION
## Summary
- add new SCA interns section to the June 2025 issue

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686eaf64c86c83208958e912dcbdfcdd