### PR TITLE
Add script to track uploaded newsletter files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ All links use relative paths so you can drop these files onto any web server or 
 1. Create a folder in `issues/` named for the issue (e.g. `Jan2026`).
 2. Add your HTML file and any images used by that issue inside the folder.
 3. Update `newsletter.html` to link to the new issue.
+4. Run `python3 track_uploads.py` to record the new issue in `upload_history.json`.
+
+## Tracking uploaded issues
+
+The `track_uploads.py` script helps avoid re-uploading the same newsletter files. It compares the HTML files in `issues/` against the list saved in `upload_history.json` and reports anything new.
+
+```bash
+python3 track_uploads.py
+```
+
+Running the script updates `upload_history.json` with any newly detected issue files so future runs only report untracked files.
 
 ## Local development
 
@@ -34,4 +45,3 @@ Then visit [http://localhost:8000](http://localhost:8000) and click around!
 ---
 
 Happy wading!
-

--- a/track_uploads.py
+++ b/track_uploads.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Track newsletter issues that have been uploaded.
+
+This script compares HTML files in the ``issues`` directory against a
+JSON file that records which issue files have already been handled.
+New issue files are printed so that they can be uploaded or compiled,
+and the JSON file is updated accordingly.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# File that stores the record of processed issue HTML files
+HISTORY_PATH = Path('upload_history.json')
+
+
+def load_history() -> set[str]:
+    """Load the set of previously processed issue files."""
+    if HISTORY_PATH.exists():
+        try:
+            return set(json.loads(HISTORY_PATH.read_text()))
+        except json.JSONDecodeError:
+            return set()
+    return set()
+
+
+def save_history(history: set[str]) -> None:
+    """Persist the history of processed files to ``HISTORY_PATH``."""
+    HISTORY_PATH.write_text(
+        json.dumps(sorted(history), indent=2) + "\n"
+    )
+
+
+def find_issue_files() -> set[str]:
+    """Return the set of newsletter HTML files under ``issues/``."""
+    return {
+        str(path)
+        for path in Path('issues').rglob('*Newsletter.html')
+        if path.is_file()
+    }
+
+
+def main() -> None:
+    history = load_history()
+    current = find_issue_files()
+    new_files = sorted(current - history)
+
+    if new_files:
+        print("New issue files detected:")
+        for file in new_files:
+            print(f" - {file}")
+        history.update(new_files)
+        save_history(history)
+    else:
+        print("No new issue files found.")
+
+
+if __name__ == '__main__':
+    main()

--- a/upload_history.json
+++ b/upload_history.json
@@ -1,0 +1,7 @@
+[
+  "issues/DecJan2025/DecJan2025Newsletter.html",
+  "issues/April2025/MarchApril2025Newsletter.html",
+  "issues/May2025/May2025Newsletter.html",
+  "issues/June2025/June2025Newsletter.html",
+  "issues/July2025/July2025Newsletter.html"
+]


### PR DESCRIPTION
## Summary
- add `track_uploads.py` to record newsletter HTML files that have already been processed
- store existing issue files in `upload_history.json`
- document usage of the tracker in README

## Testing
- `python3 track_uploads.py`
- `python -m py_compile track_uploads.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1c7808c908320ac2440449e3be900