### PR TITLE
Add Satus Creek eDNA image to July-August 2025 issue

### DIFF
--- a/issues/August2025/JulyAugust2025Newsletter.html
+++ b/issues/August2025/JulyAugust2025Newsletter.html
@@ -170,6 +170,7 @@
 
     <!-- Satus Creek Mussel eDNA -->
     <table role="presentation" width="100%" class="card"><tr>
+      <td class="imgCol"><img loading="lazy" src="Satus.png" alt="Collecting eDNA samples at Satus Creek"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Satus Creek Mussel eDNA</h2>
         <p>Staff collected <strong>eDNA</strong> samples from multiple sites in <strong>Satus Creek</strong> to better understand the distribution of four freshwater mussel species in the lower <strong>Yakima Basin</strong>: <strong>Western Pearlshell</strong>, <strong>Western Ridged</strong>, <strong>Oregon Floater</strong>, and <strong>California Floater</strong>.</p>


### PR DESCRIPTION
## Summary
- add the Satus Creek field photo to the Mussel eDNA section of the July–August 2025 issue

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cab699e4f083209de35acfeb8e0403