### PR TITLE
Add April 2026 newsletter issue and update newsletter index

### DIFF
--- a/issues/April2026/April2026Newsletter.html
+++ b/issues/April2026/April2026Newsletter.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="x-ua-compatible" content="IE=edge">
+  <title>USFWS - Yakima Newsletter | April 2026</title>
+  <meta property="og:title" content="USFWS - Yakima Newsletter | April 2026">
+  <meta property="og:description" content="U.S. Fish &amp; Wildlife Service Yakima Newsletter">
+  <meta property="og:image" content="../../assets/hero/Gyokatsu.png">
+  <meta property="og:type" content="article">
+  <link href="https://fonts.googleapis.com/css2?family=Newsreader:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --primary:#4c7eb0;
+      --secondary:#FFFFFF;
+      --accent1:#e09f1f;
+      --accent2:#FFFFFF;
+      --neutral-light:#d9f3ff;
+      --highlight:#000000;
+    }
+    body{margin:0;background:#a0acbd;font-family:'Newsreader',serif;color:#000000;opacity:0;transition:opacity 0.5s ease-in-out;}
+    body.fade-in{opacity:1;}
+    body.fade-out{opacity:0;}
+    *,*::before,*::after{box-sizing:border-box;}
+    table{border-collapse:collapse!important;width:100%;}
+    img{display:block;border:0;outline:none;text-decoration:none;width:100%;height:auto;border-radius:12px;}
+    h1,h2{margin:0;font-family:Helvetica,Arial,sans-serif;}
+    h1{font-size:60px;line-height:1.2;font-weight:700;color:var(--neutral-light);letter-spacing:0.6px;}
+    h2{font-size:42px;line-height:1.3;font-weight:600;color:var(--primary);letter-spacing:0.25px;}
+    p,ul,li{margin:16px 0;font-size:27px;line-height:1.6;font-weight:400;}
+    ul{padding-left:28px;}
+    .mast{background:var(--primary);border-radius:0 0 16px 16px;width:calc(100% + 36px);margin:0 -18px;}
+    .mastInner td{vertical-align:bottom;}
+    .mastInner .titleCell{padding:60px 4%;text-align:center;}
+    .mastInner .imgCell{width:180px;padding:0 0 12px 4%;}
+    .card{background:#FFFFFF;background:var(--accent2);border:1px solid var(--accent1);border-radius:16px;margin-top:36px;overflow:hidden;}
+    .pad{padding:38px 5%;}
+    .imgCol{width:42%;vertical-align:top;}
+    .txtCol{width:58%;vertical-align:top;padding-left:34px;}
+    .subhead{font-size:30px;font-weight:500;line-height:1.5;text-transform:uppercase;text-align:center;margin:14px 0 22px;color:#000;letter-spacing:0.3px;font-family:Helvetica,Arial,sans-serif;}
+    .menu-bar{
+      background:linear-gradient(90deg, var(--primary), var(--accent1));
+      padding:0.5em 1em;
+      position:sticky;
+      top:0;
+      box-shadow:0 2px 4px rgba(0,0,0,0.15);
+      z-index:100;
+      display:flex;
+      align-items:center;
+    }
+    .menu-btn{font-size:36px;line-height:1.2;font-weight:600;color:var(--neutral-light);background:none;border:none;cursor:pointer;transition:transform 0.2s;}
+    .home-btn{font-size:42px;line-height:1.2;font-weight:600;color:var(--neutral-light);text-decoration:none;margin-left:0.5em;display:flex;align-items:center;transition:transform 0.2s;}
+    .home-btn svg{width:1em;height:1em;fill:currentColor;}
+    .menu-items{display:none;flex-direction:column;position:fixed;top:3em;left:0;width:220px;height:auto;padding:1em;gap:0.5em;background:linear-gradient(90deg, var(--primary), var(--accent1));z-index:101;}
+    .menu-items a{color:var(--neutral-light);text-decoration:none;font-size:30px;line-height:1.3;font-weight:500;margin:0.25em 0;transition:transform 0.2s;}
+    .menu-btn:hover,.home-btn:hover,.menu-items a:hover{color:var(--accent1);transform:scale(1.1);}
+    .menu-items.show{display:flex;}
+    .page{padding:0 18px;}
+    @media only screen and (max-width:720px){
+      h1{font-size:45px;line-height:1.2;}
+      h2{font-size:33px;line-height:1.3;}
+      p,ul,li{font-size:24px;}
+      .subhead{font-size:27px;line-height:1.5;}
+      .menu-btn{font-size:33px;}
+      .home-btn{font-size:36px;}
+      .menu-items a{font-size:27px;}
+      .imgCol,.txtCol{display:block;width:100%!important;padding:0!important;}
+      .txtCol{padding:28px 6%!important;}
+      .mastInner .imgCell{display:none!important;}
+      .mastInner .titleCell{padding:40px 6%!important;}
+      .menu-items a{flex-basis:100%;}
+    }
+    footer{background:#4c7eb0;color:#d9f3ff;text-align:center;padding:0.5em 0;}
+    footer a{color:orange;}
+  </style>
+</head>
+<body>
+  <nav class="menu-bar">
+    <button id="menuBtn" class="menu-btn">&#9776;</button>
+    <a href="../../newsletter.html" class="home-btn" aria-label="Home">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 9.5 12 3l9 6.5V21a1 1 0 0 1-1 1h-5v-7H9v7H4a1 1 0 0 1-1-1V9.5z"/>
+      </svg>
+    </a>
+    <div id="menuItems" class="menu-items">
+      <a href="../DecJan2025/DecJan2025Newsletter.html">Dec - Jan 2025</a>
+      <a href="../April2025/MarchApril2025Newsletter.html">Mar - Apr 2025</a>
+      <a href="../May2025/May2025Newsletter.html">May 2025</a>
+      <a href="../June2025/June2025Newsletter.html">June 2025</a>
+      <a href="../August2025/JulyAugust2025Newsletter.html">Jul - Aug 2025</a>
+      <a href="../October2025/SeptemberOctober2025Newsletter.html">Sep - Oct 2025</a>
+      <a href="April2026Newsletter.html">April 2026</a>
+    </div>
+  </nav>
+
+  <table role="presentation" bgcolor="#a0acbd" style="background:#a0acbd;" cellspacing="0" cellpadding="0"><tr><td class="page">
+
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" bgcolor="#4c7eb0" style="background:var(--primary);" class="mast">
+      <tr>
+        <td bgcolor="#4c7eb0" style="background:var(--primary); padding:0;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+            <tr class="mastInner">
+              <td class="imgCell" bgcolor="#4c7eb0" style="background:var(--primary);">
+                <img loading="lazy" src="../../assets/logo/usfws-logo.webp" alt="USFWS logo" width="180" style="display:block;border:0;width:100%;height:auto;">
+              </td>
+              <td class="titleCell" bgcolor="#4c7eb0" style="background:var(--primary);" align="center" valign="bottom">
+                <h1>U.S. Fish and Wildlife Service&nbsp;&ndash;&nbsp;Yakima<br>Newsletter</h1>
+                <p style="margin:12px 0 0;font-size:30px;line-height:1.4;font-weight:400;letter-spacing:0.3px;color:var(--highlight);">
+                  April&nbsp;2026
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+
+    <div class="page">
+
+    <table role="presentation" width="100%" class="card"><tr>
+      <td class="imgCol"><img loading="lazy" src="../April2025/CleElumNetting.JPG" alt="Cle Elum Reservoir netting operations"></td>
+      <td class="txtCol pad">
+        <h2 style="text-align:center;">Cle Elum Sockeye Collection</h2>
+        <p class="subhead">Spring operations underway</p>
+        <p>Netting operations are underway at <strong>Cle Elum Reservoir</strong>, where crews have already captured <strong>several thousand sockeye smolts</strong>. These efforts continue to provide a critical interim pathway for juvenile fish while long-term passage infrastructure is fully integrated into operations.</p>
+        <p>Tagging support is being led by partner agencies: <strong>USGS</strong> is conducting <strong>acoustic tagging</strong>, and the <strong>Yakama Nation</strong> is conducting <strong>PIT tagging</strong>. Together, these datasets will improve our understanding of fish movement, survival, and migration timing across the basin.</p>
+      </td>
+    </tr></table>
+
+    <table role="presentation" width="100%" class="card"><tr>
+      <td class="txtCol pad">
+        <h2 style="text-align:center;">Winter Flood Impacts and Rebuild</h2>
+        <p class="subhead">Recovery and restoration</p>
+        <p>The <strong>December 2025 flood events</strong> caused substantial damage to field infrastructure, including the loss of multiple <strong>PIT tag arrays</strong> and associated antenna systems.</p>
+        <p>Since winter, staff have been evaluating damage, prioritizing replacement sites, and initiating phased rebuilds to restore monitoring coverage before peak seasonal fish movement.</p>
+      </td>
+      <td class="imgCol"><img loading="lazy" src="../October2025/New-Antennas.JPG" alt="PIT antenna infrastructure in the Yakima Basin"></td>
+    </tr></table>
+
+    <table role="presentation" width="100%" class="card"><tr>
+      <td class="imgCol"><img loading="lazy" src="../August2025/Satus2.0.png" alt="Satus Creek weir installation support"></td>
+      <td class="txtCol pad">
+        <h2 style="text-align:center;">Winter Reporting and Partner Support</h2>
+        <p class="subhead">Off-season productivity</p>
+        <p>During the winter period, the team advanced multiple <strong>reports and publications</strong> supporting ongoing monitoring, evaluation, and restoration efforts throughout the Yakima Basin.</p>
+        <p>Staff also supported partner priorities in the field, including assistance with the <strong>Yakama Nation Satus Creek weir installation</strong>, helping prepare for spring and summer operations.</p>
+      </td>
+    </tr></table>
+
+    <table role="presentation" width="100%" class="card"><tr>
+      <td class="txtCol pad">
+        <h2 style="text-align:center;">Welcome Dominic Singh</h2>
+        <p class="subhead">New seasonal technician</p>
+        <p>Please join us in welcoming <strong>Dominic Singh</strong>, a <strong>6-month technician</strong> who began with our team on <strong>April 6, 2026</strong>.</p>
+        <p>Dominic brings several years of Yakima Basin field experience and most recently served as <strong>Head Field Technician for the Bull Trout Task Force</strong>. We are excited to have his expertise supporting this season&rsquo;s projects.</p>
+      </td>
+      <td class="imgCol"><img loading="lazy" src="../June2025/Lauren.jpg" alt="Field technician preparing equipment"></td>
+    </tr></table>
+
+    </div>
+  </td></tr></table>
+
+  <script src="../../fade.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      const menuBtn = document.getElementById('menuBtn');
+      const menuItems = document.getElementById('menuItems');
+      menuBtn.addEventListener('click', function(){
+        menuItems.classList.toggle('show');
+      });
+    });
+  </script>
+  <footer>Created by <a href="https://conman515.github.io/ConnorCunningham_CV/">Connor Cunningham</a> 2025</footer>
+</body>
+</html>

--- a/newsletter.html
+++ b/newsletter.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Yakima Newsletter | 2025</title>
-  <meta property="og:title" content="Yakima Newsletter – 2025">
+  <title>Yakima Newsletter | 2025-2026</title>
+  <meta property="og:title" content="Yakima Newsletter – 2025-2026">
   <meta property="og:description" content="U.S. Fish &amp; Wildlife Service Yakima Newsletter">
   <meta property="og:image" content="assets/hero/Gyokatsu.png">
   <meta property="og:type" content="website">
@@ -39,7 +39,7 @@
       border-radius: clamp(28px, 5vw, 40px);
       overflow: hidden;
       color: #fff;
-      background: url('issues/October2025/Keechelus-Picket-Weir.JPG') center / cover no-repeat;
+      background: url('issues/April2025/CleElumNetting.JPG') center / cover no-repeat;
       box-shadow: 0 40px 70px rgba(10, 23, 46, 0.35);
       isolation: isolate;
     }
@@ -298,6 +298,7 @@
               <li><a href="issues/June2025/June2025Newsletter.html">June 2025</a></li>
               <li><a href="issues/August2025/JulyAugust2025Newsletter.html">Jul &ndash; Aug 2025</a></li>
               <li><a href="issues/October2025/SeptemberOctober2025Newsletter.html">Sep &ndash; Oct 2025</a></li>
+              <li><a href="issues/April2026/April2026Newsletter.html">April 2026</a></li>
             </ul>
           </li>
           <li><a href="reports.html">Reports</a></li>
@@ -307,10 +308,10 @@
     <main>
       <section class="hero">
         <div class="hero__content">
-          <h1>Yakima Newsletter &ndash; 2025</h1>
-          <p>Catch up on hatchery news, habitat projects, and field notes from the Yakima River Basin&mdash;all curated by the team on the water.</p>
+          <h1>Yakima Newsletter &ndash; 2025-2026</h1>
+          <p>Catch up on hatchery news, habitat projects, and field notes from the Yakima River Basin&mdash;all curated by the team on the water from 2025 into 2026.</p>
           <div class="hero__cta">
-            <a class="btn btn-primary" href="issues/October2025/SeptemberOctober2025Newsletter.html">Read latest issue</a>
+            <a class="btn btn-primary" href="issues/April2026/April2026Newsletter.html">Read latest issue</a>
             <a class="btn btn-secondary" href="#issue-archive">Explore the archive</a>
           </div>
         </div>
@@ -318,7 +319,7 @@
       <section class="page-section" id="issue-archive">
         <div class="section-intro">
           <h2>Explore Past Issues</h2>
-          <p>Browse every 2025 volume to see how fisheries crews, biologists, and partners are restoring the Yakima watershed throughout the seasons.</p>
+          <p>Browse every published volume to see how fisheries crews, biologists, and partners are restoring the Yakima watershed throughout the seasons.</p>
         </div>
         <div class="issue-grid">
           <a class="issue-card" href="issues/DecJan2025/DecJan2025Newsletter.html">
@@ -342,9 +343,13 @@
             <span>Jul - Aug 2025</span>
           </a>
           <a class="issue-card" href="issues/October2025/SeptemberOctober2025Newsletter.html">
-            <span class="badge">Latest</span>
             <img loading="lazy" src="issues/October2025/Keechelus-Picket-Weir.JPG" alt="Sep - Oct 2025">
             <span>Sep - Oct 2025</span>
+          </a>
+          <a class="issue-card" href="issues/April2026/April2026Newsletter.html">
+            <span class="badge">Latest</span>
+            <img loading="lazy" src="issues/April2025/CleElumNetting.JPG" alt="April 2026">
+            <span>April 2026</span>
           </a>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Publish the April 2026 newsletter issue and surface it as the latest issue in the site index and navigation. 
- Update the newsletter landing copy and hero to reflect coverage spanning 2025 into 2026.

### Description
- Added a new issue page at `issues/April2026/April2026Newsletter.html` containing the April 2026 newsletter HTML and styles. 
- Updated `newsletter.html` metadata and heading to `2025-2026` and adjusted the Open Graph title to match. 
- Replaced the hero background and copy to reference the updated timeframe and switched the hero CTA to point to `issues/April2026/April2026Newsletter.html`. 
- Updated the newsletter submenu and archive grid in `newsletter.html` to include an `April 2026` entry and moved the `Latest` badge to the new issue.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c715866c83208c8c3060b5c58418)