### PR TITLE
April 2026 newsletter: copy fixes, image updates, and Fisheries Academy feature

### DIFF
--- a/issues/April2026/April2026Newsletter.html
+++ b/issues/April2026/April2026Newsletter.html
@@ -123,8 +123,8 @@
       <td class="txtCol pad">
         <h2 style="text-align:center;">Cle Elum Sockeye Collection</h2>
         <p class="subhead">Spring operations underway</p>
-        <p>Crew has completed netting opperations at <strong>Cle Elum Reservoir</strong>, where crews captured <strong>several thousand sockeye smolts</strong>.</p>
-        <p>Tagging support is being led by partner agencies: <strong>USGS</strong> is conducting <strong>acoustic tagging</strong>, and the <strong>Yakama Nation</strong> is conducting <strong>PIT tagging</strong>. Together, these datasets will improve our understanding of fish movement, survival, and migration through "The Helix" a juvenile by-pass facility which is fully opperational for the first time this year.</p>
+        <p>Crew has completed netting operations at <strong>Cle Elum Reservoir</strong>, where crews captured <strong>several thousand sockeye smolts</strong>.</p>
+        <p>Tagging support is being led by partner agencies: <strong>USGS</strong> is conducting <strong>acoustic tagging</strong>, and the <strong>Yakama Nation</strong> is conducting <strong>PIT tagging</strong>. Together, these datasets will improve our understanding of fish movement, survival, and migration through "The Helix," a juvenile bypass facility that is fully operational for the first time this year.</p>
       </td>
     </tr></table>
 
@@ -139,12 +139,22 @@
     </tr></table>
 
     <table role="presentation" width="100%" class="card"><tr>
-      <td class="imgCol"><img loading="lazy" src="../August2025/Satus2.0.png" alt="Satus Creek weir installation support"></td>
+      <td class="imgCol"><img loading="lazy" src="../October2025/Box-Canyon-Creek-Flume.jpeg" alt="Satus Creek weir installation support"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Winter Reporting and Partner Support</h2>
         <p class="subhead">Off-season productivity</p>
         <p>During the winter period, the team advanced multiple <strong>reports and publications</strong> supporting ongoing monitoring, evaluation, and restoration efforts throughout the Yakima Basin.</p>
-        <p>Staff also supported partner priorities in the field, including assistance with the <strong>Yakama Nation Satus Creek weir installation and Bureua of Reclamation staff with fish salvage</strong>.</p>
+        <p>Staff also supported partner priorities in the field, including assistance with the <strong>Yakama Nation Satus Creek weir installation and Bureau of Reclamation fish salvage efforts</strong>.</p>
+        <p>Connor Cunningham also attended <strong>Fisheries Academy</strong>, a two-week course designed to inspire and educate the future leaders of the U.S. Fish and Wildlife Service&rsquo;s <strong>Fish and Aquatic Conservation (FAC) Program</strong>.</p>
+      </td>
+    </tr></table>
+
+    <table role="presentation" width="100%" class="card"><tr>
+      <td class="imgCol"><img loading="lazy" src="../October2025/SCA-Crew-Completion.JPG" alt="Fisheries Academy 2026 celebration cake"></td>
+      <td class="txtCol pad">
+        <h2 style="text-align:center;">Fisheries Academy 2026</h2>
+        <p class="subhead">Leadership development</p>
+        <p>Congratulations to <strong>Connor Cunningham</strong> for completing <strong>Fisheries Academy</strong>, a two-week course designed to inspire and educate the future leaders of the U.S. Fish and Wildlife Service&rsquo;s <strong>Fish and Aquatic Conservation (FAC) Program</strong>.</p>
       </td>
     </tr></table>
 


### PR DESCRIPTION
### Motivation
- Correct copy errors and improve clarity in the April 2026 newsletter content.  
- Replace outdated image references with updated photos and add a brief highlight for Fisheries Academy participation.  

### Description
- Fixed typos and phrasing in `issues/April2026/April2026Newsletter.html`, including `opperations` → `operations`, `opperational` → `operational`, and `by-pass` → `bypass`, and added a comma in the Helix sentence for clarity.  
- Updated image sources to new assets: replaced `../August2025/Satus2.0.png` with `../October2025/Box-Canyon-Creek-Flume.jpeg` and added `../October2025/SCA-Crew-Completion.JPG` for the Fisheries Academy card.  
- Corrected agency name and phrasing for partner support to `Bureau of Reclamation fish salvage efforts`.  
- Added a new card section highlighting `Fisheries Academy 2026` and congratulating `Connor Cunningham` on completion.  

### Testing
- No automated tests were run for this content/HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d3442e0c83209bd1b84e262c124e)