### PR TITLE
Fix April 2026 newsletter page not rendering

### DIFF
--- a/issues/April2026/April2026Newsletter.html
+++ b/issues/April2026/April2026Newsletter.html
@@ -170,3 +170,17 @@
 
     </div>
   </td></tr></table>
+
+  <script src="../../fade.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      const menuBtn = document.getElementById('menuBtn');
+      const menuItems = document.getElementById('menuItems');
+      menuBtn.addEventListener('click', function(){
+        menuItems.classList.toggle('show');
+      });
+    });
+  </script>
+  <footer>Created by <a href="https://conman515.github.io/ConnorCunningham_CV/">Connor Cunningham</a> 2026</footer>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- The April 2026 newsletter HTML file was truncated at the end, leaving out the shared scripts and closing HTML tags which caused the page to remain invisible due to the `body` starting at `opacity:0` and no fade script to toggle it.
- Restoring the shared scripts and footer aligns this issue page with other newsletters and re-enables the navigation menu and fade-in UX.

### Description
- Added the shared `fade.js` include and the inline menu toggle script to `issues/April2026/April2026Newsletter.html`.
- Appended the footer block and the missing closing `</body>` and `</html>` tags to complete the document structure.
- Only `issues/April2026/April2026Newsletter.html` was modified.

### Testing
- Inspected the updated file with `sed`, `tail`, and `nl` to verify the script, footer, and closing tags are present and well-formed, and those checks passed.
- Reviewed the repository diff to confirm that only `issues/April2026/April2026Newsletter.html` was changed, and that check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d78ac5cc832097b2e587ca0b950e)