### PR TITLE
Fix April 2026 newsletter image references and Dominic role wording

### DIFF
--- a/issues/April2026/April2026Newsletter.html
+++ b/issues/April2026/April2026Newsletter.html
@@ -135,11 +135,11 @@
         <p>The <strong>December 2025 flood events</strong> caused substantial damage to field infrastructure, including the loss of multiple <strong>PIT tag arrays</strong> and associated antenna systems.</p>
         <p>Since winter, staff have been evaluating damage, prioritizing replacement sites, and initiating phased rebuilds to restore monitoring coverage before peak seasonal fish movement.</p>
       </td>
-      <td class="imgCol"><img loading="lazy" src="Winter-Flood-PIT-Array.jpg" alt="PIT antenna infrastructure in the Yakima Basin"></td>
+      <td class="imgCol"><img loading="lazy" src="DecemberFloods.JPG" alt="PIT antenna infrastructure in the Yakima Basin"></td>
     </tr></table>
 
     <table role="presentation" width="100%" class="card"><tr>
-      <td class="imgCol"><img loading="lazy" src="Winter-Rebuild-Coiled-Antenna.jpg" alt="Satus Creek weir installation support"></td>
+      <td class="imgCol"><img loading="lazy" src="AntennaConstruction.JPG" alt="Satus Creek weir installation support"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Winter Reporting and Partner Support</h2>
         <p class="subhead">Off-season productivity</p>
@@ -150,7 +150,7 @@
     </tr></table>
 
     <table role="presentation" width="100%" class="card"><tr>
-      <td class="imgCol"><img loading="lazy" src="Fisheries-Academy-Cake-2026.jpg" alt="Fisheries Academy 2026 celebration cake"></td>
+      <td class="imgCol"><img loading="lazy" src="Fish Acadamey.JPG" alt="Fisheries Academy 2026 celebration cake"></td>
       <td class="txtCol pad">
         <h2 style="text-align:center;">Fisheries Academy 2026</h2>
         <p class="subhead">Leadership development</p>
@@ -163,9 +163,9 @@
         <h2 style="text-align:center;">Welcome Dominic Singh</h2>
         <p class="subhead">New seasonal technician</p>
         <p>Please join us in welcoming <strong>Dominic Singh</strong>, a <strong>6-month technician</strong> who began with our team on <strong>April 6, 2026</strong>.</p>
-        <p>Dominic brings several years of Yakima Basin field experience and most recently served as <strong>Head Field Technician for the Bull Trout Task Force</strong>. We are excited to have his expertise supporting this season&rsquo;s projects.</p>
+        <p>Dominic brings several years of Yakima Basin field experience and most recently served as <strong>Lead Field Technician for the Bull Trout Task Force</strong>. We are excited to have his expertise supporting this season&rsquo;s projects.</p>
       </td>
-      <td class="imgCol"><img loading="lazy" src="../June2025/Lauren.jpg" alt="Field technician preparing equipment"></td>
+      <td class="imgCol"><img loading="lazy" src="Dominic1.jpeg" alt="Field technician preparing equipment"></td>
     </tr></table>
 
     </div>


### PR DESCRIPTION
### Motivation
- Ensure the April 2026 newsletter displays the correct local images so all visual assets resolve for readers.
- Correct Dominic’s role wording to accurately reflect his position in the biography section.

### Description
- Updated image references in `issues/April2026/April2026Newsletter.html` swapping `Winter-Flood-PIT-Array.jpg` for `DecemberFloods.JPG`, `Winter-Rebuild-Coiled-Antenna.jpg` for `AntennaConstruction.JPG`, and `Fisheries-Academy-Cake-2026.jpg` for `Fish Acadamey.JPG`.
- Replaced the Dominic section photo reference `../June2025/Lauren.jpg` with `Dominic1.jpeg` from the April 2026 folder.
- Replaced the text `Head Field Technician` with `Lead Field Technician` in Dominic’s paragraph for accurate wording.

### Testing
- Confirmed the new image files exist with `test -f issues/April2026/DecemberFloods.JPG && test -f issues/April2026/AntennaConstruction.JPG && test -f 'issues/April2026/Fish Acadamey.JPG' && test -f issues/April2026/Dominic1.jpeg`, which returned `OK`.
- Confirmed the old image names and previous title text are no longer present using `! rg -n "Winter-Flood-PIT-Array.jpg|Winter-Rebuild-Coiled-Antenna.jpg|Fisheries-Academy-Cake-2026.jpg|../June2025/Lauren.jpg|Head Field Technician" issues/April2026/April2026Newsletter.html`, which returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8da90889c832088064d5c95c4aecc)