### PR TITLE
Update April 2026 reporting photo

### DIFF
--- a/issues/April2026/April2026Newsletter.html
+++ b/issues/April2026/April2026Newsletter.html
@@ -151,7 +151,7 @@
           <table role="presentation" width="100%" class="card">
             <tr>
               <td class="imgCol">
-                <img loading="lazy" src="SatusWeir.jpg" alt="Satus Creek weir installation support">
+                <img loading="lazy" src="seasonal_UDs_isopleths_v2.png" alt="Seasonal Bull Trout utilization distribution isopleths">
               </td>
               <td class="txtCol pad">
                 <h2 style="text-align:center;">Analysis and Reporting</h2>


### PR DESCRIPTION
### Motivation
- Replace the weir photo in the newsletter's "Analysis and Reporting" panel with a seasonal UDs isopleths image to better illustrate winter analysis results.

### Description
- In `issues/April2026/April2026Newsletter.html` replaced `src="SatusWeir.jpg"` with `src="seasonal_UDs_isopleths_v2.png"` and updated the `alt` text to "Seasonal Bull Trout utilization distribution isopleths".

### Testing
- Ran a scripted verification that `issues/April2026/seasonal_UDs_isopleths_v2.png` exists and that `issues/April2026/April2026Newsletter.html` contains `src="seasonal_UDs_isopleths_v2.png"` and no longer contains `src="SatusWeir.jpg"`, and those assertions passed; an automated check for local rendering tools (`chromium`, `google-chrome`, `playwright`, `wkhtmltoimage`) found none so a rendered preview was not generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06122c30148320b3b4dc8895a7f1c6)